### PR TITLE
Minor fix up of ant.py

### DIFF
--- a/etc/dbus-serialbattery/ant.py
+++ b/etc/dbus-serialbattery/ant.py
@@ -7,7 +7,7 @@ from struct import *
 
 class Ant(Battery):
 
-    def __init__(self, port, baud, address):
+    def __init__(self, port, baud):
         super(Ant, self).__init__(port, baud)
         self.type = self.BATTERYTYPE
 


### PR DESCRIPTION
My ANT BMS still not yet arrived, but my Daly (Or MGod) BMS arrived. While testing it with the ant branch I noticed that there is a method parameter not matching resulting in the driver didn't load up successfully:

```
root@raspberrypi2:~# tail -f /data/log/dbus-serialbattery.ttyUSB1/current 
@40000000611ea4cf2f7dd834 TypeError: __init__() takes exactly 4 arguments (3 given)
@40000000611ea4e1181f8f5c INFO:__main__:dbus-serialbattery v0.5
@40000000611ea4e1182e6824 Traceback (most recent call last):
@40000000611ea4e118300e04   File "/opt/victronenergy/dbus-serialbattery/dbus-serialbattery.py", line 99, in <module>
@40000000611ea4e11833c724     main()
@40000000611ea4e11835fd8c   File "/opt/victronenergy/dbus-serialbattery/dbus-serialbattery.py", line 70, in main
@40000000611ea4e118398f9c     battery = get_battery_type(port)
@40000000611ea4e1183c0c54   File "/opt/victronenergy/dbus-serialbattery/dbus-serialbattery.py", line 41, in get_battery_type
@40000000611ea4e1183ed344     Ant(port=_port, baud=9600),
```

This change fixes it and the Daly BMS driver is successfully loaded:
```
@40000000611ea5c536bf82b4 INFO:__main__:dbus-serialbattery v0.5
@40000000611ea5c536d05364 INFO:__main__:Testing Daly
@40000000611ea5c53947fe6c INFO:utils:DalyBMS 10 cells
@40000000611ea5c6017fcfdc INFO:__main__:Battery connected to dbus from /dev/ttyUSB1
@40000000611ea5d014d71734 ERROR:utils:>>> ERROR: No reply - returning
@40000000611ea5d6185c9474 ERROR:utils:>>> ERROR: No reply - returning
@40000000611ea61219cdbc5c ERROR:utils:>>> ERROR: No reply - returning
@40000000611ea62818ad583c ERROR:utils:>>> ERROR: No reply - returning
@40000000611ea64c23e6161c ERROR:utils:>>> ERROR: No reply - returning
@40000000611ea67a24c2e18c ERROR:utils:>>> ERROR: No reply - returning
@40000000611ea68e287f0ae4 ERROR:utils:>>> ERROR: No reply - returning
@40000000611ea6b0255f8b04 ERROR:utils:>>> ERROR: No reply - returning
```