### PR TITLE
Sinowealth pyhton 3 fix and implement ConsumedAmphours on dbus

### DIFF
--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -87,6 +87,8 @@ class DbusHelper:
                                    gettextcallback=lambda p, v: "{:0.2f}Ah".format(v))
         self._dbusservice.add_path('/InstalledCapacity', self.battery.capacity, writeable=True,
                                    gettextcallback=lambda p, v: "{:0.0f}Ah".format(v))
+        self._dbusservice.add_path('/ConsumedAmphours', None, writeable=True,
+                                   gettextcallback=lambda p, v: "{:0.0f}Ah".format(v))
         # Not used at this stage
         # self._dbusservice.add_path('/System/MinTemperatureCellId', None, writeable=True)
         # self._dbusservice.add_path('/System/MaxTemperatureCellId', None, writeable=True)
@@ -151,6 +153,9 @@ class DbusHelper:
         self._dbusservice['/Dc/0/Power'] = round(self.battery.voltage * self.battery.current, 2)
         self._dbusservice['/Dc/0/Temperature'] = self.battery.get_temp()
         self._dbusservice['/Capacity'] = self.battery.capacity_remain
+        self._dbusservice['/ConsumedAmphours'] = 0 if self.battery.capacity is None or \
+                                self.battery.capacity_remain is None else \
+                                self.battery.capacity - self.battery.capacity_remain
         
         midpoint, deviation = self.battery.get_midvoltage()
         if (midpoint is not None):


### PR DESCRIPTION
Hi @Louisvdw

I got to test the 0.9 release on Venus  2.80~21, found that the sinowealth code still has some issues.

Also the "ConsumedAmphours" is implemented on Dbus, which provides the consumed amp hours in VRM advanced view.

The rest is cleanup and unused stuff. The "total_ah_drawn" would be nice to implement in the battery class, this needs summing up al use over time, so it needs some calculations.

Greets Sander