### PR TITLE
Change first line of rc.local

### DIFF
--- a/rc.local
+++ b/rc.local
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ln -s /data/etc/dbus-serialbattery /opt/victronenergy/dbus-serialbattery
 ln -s /data/etc/dbus-serialbattery/service /opt/victronenergy/service/dbus-serialbattery
 ln -s /data/etc/dbus-serialbattery/service /opt/victronenergy/service-templates/dbus-serialbattery


### PR DESCRIPTION
Hi @Louisvdw 

As mentioned before, I had the issue that the symlinks in the rc.local where not created on boot. Running the rc.local file manually was working fine.

After a bit of testing it seems to work by changing the first line to #!/bin/bash in stead off #!/bin/sh

Regards,

Sander