### PR TITLE
Online status

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -36,6 +36,7 @@ class Battery(object):
         self.role = 'battery'
         self.type = 'Generic'
         self.poll_interval = 1000
+        self.online = True
 
         self.hardware_version = None
         self.voltage = None

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -80,7 +80,7 @@ def main():
     # exit if no battery could be found
     if battery is None:
         logger.error("ERROR >>> No battery connection at " + port)
-        return
+        sys.exit(1)
 
     # Have a mainloop, so we can send/receive asynchronous calls to and from dbus
     DBusGMainLoop(set_as_default=True)
@@ -92,7 +92,7 @@ def main():
     helper = DbusHelper(battery)
     if not helper.setup_vedbus():
         logger.error("ERROR >>> Problem with battery set up at " + port)
-        return
+        sys.exit(1)
     logger.warning('Battery connected to dbus from ' + port)
 
 

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.WARNING)
 
 # Constants - Need to dynamically get them in future
 DRIVER_VERSION = 0.9
-DRIVER_SUBVERSION = ''
+DRIVER_SUBVERSION = '.1beta1'
 zero_char = chr(48)
 degree_sign = u'\N{DEGREE SIGN}'
 # Cell min/max voltages - used with the cell count to get the min/max battery voltage

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.WARNING)
 
 # Constants - Need to dynamically get them in future
 DRIVER_VERSION = 0.9
-DRIVER_SUBVERSION = '.1beta1'
+DRIVER_SUBVERSION = '.1'
 zero_char = chr(48)
 degree_sign = u'\N{DEGREE SIGN}'
 # Cell min/max voltages - used with the cell count to get the min/max battery voltage


### PR DESCRIPTION
Closes #17 to show when bank is offline when no reply is recieved in 10 iterations (10 sec. for most batteries)
Exit with status 1 for python 3 when no battery is found.
Fix on device instance