### PR TITLE
Cell Voltages

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -155,6 +155,20 @@ class Battery(object):
         cell_no = self.get_max_cell()
         return cell_no if cell_no is None else 'C' + str(cell_no + 1)
 
+#cell voltages - begining
+    def get_cell_voltage(self, idx):
+        if idx>=min(len(self.cells), self.cell_count):
+          return None
+        return self.cells[idx].voltage
+ 
+    def get_cell_balancing(self, idx):
+        if idx>=min(len(self.cells), self.cell_count):
+          return None
+        if self.cells[idx].balance is not None and self.cells[idx].balance:
+          return 1
+        return 0
+# - end
+
     def get_min_cell_voltage(self):
         min_voltage = None
         if len(self.cells) == 0 and hasattr(self, 'cell_min_voltage'):

--- a/etc/dbus-serialbattery/installqml.sh
+++ b/etc/dbus-serialbattery/installqml.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#backup old PageBattery.qml
+cp /opt/victronenergy/gui/qml/PageBattery.qml /opt/victronenergy/gui/qml/PageBattery.qml.backup
+#copy new PageBattery.qml
+cp /data/etc/dbus-serialbattery/qml/PageBattery.qml /opt/victronenergy/gui/qml/
+#copy new PageBatteryCellVoltages
+cp /data/etc/dbus-serialbattery/qml/PageBatteryCellVoltages.qml /opt/victronenergy/gui/qml/
+#stop gui
+svc -d /service/gui
+#sleep 1 sec
+sleep 1
+#start gui
+svc -u /service/gui

--- a/etc/dbus-serialbattery/qml/PageBattery.qml
+++ b/etc/dbus-serialbattery/qml/PageBattery.qml
@@ -1,0 +1,333 @@
+import QtQuick 1.1
+import com.victron.velib 1.0
+
+MbPage {
+	id: root
+
+	property variant service
+	property string bindPrefix
+
+	property VBusItem hasSettings: VBusItem { bind: service.path("/Settings/HasSettings") }
+	property VBusItem dcVoltage: VBusItem { bind: service.path("/Dc/0/Voltage") }
+	property VBusItem dcCurrent: VBusItem { bind: service.path("/Dc/0/Current") }
+	property VBusItem midVoltage: VBusItem { bind: service.path("/Dc/0/MidVoltage") }
+	property VBusItem productId: VBusItem { bind: service.path("/ProductId") }
+	property VBusItem cell1: VBusItem { bind: service.path("/Voltages/Cell1") }
+
+	property bool isFiamm48TL: productId.value === 0xB012
+
+	title: service.description
+	summary: [soc.item.format(0), dcVoltage.text, dcCurrent.text]
+
+	model: VisualItemModel {
+		MbItemOptions {
+			description: qsTr("Switch")
+			bind: service.path("/Mode")
+			show: item.valid
+
+			possibleValues: [
+				MbOption { description: qsTr("Off"); value: 4; readonly: true },
+				MbOption { description: qsTr("Standby"); value: 0xfc },
+				MbOption { description: qsTr("On"); value: 3 }
+			]
+		}
+
+		MbItemOptions {
+			description: qsTr("State")
+			bind: service.path("/State")
+			readonly: true
+			show: item.valid
+			possibleValues:[
+				MbOption { description: qsTr("Initializing"); value: 0 },
+				MbOption { description: qsTr("Initializing"); value: 1 },
+				MbOption { description: qsTr("Initializing"); value: 2 },
+				MbOption { description: qsTr("Initializing"); value: 3 },
+				MbOption { description: qsTr("Initializing"); value: 4 },
+				MbOption { description: qsTr("Initializing"); value: 5 },
+				MbOption { description: qsTr("Initializing"); value: 6 },
+				MbOption { description: qsTr("Initializing"); value: 7 },
+				MbOption { description: qsTr("Initializing"); value: 8 },
+				MbOption { description: qsTr("Running"); value: 9 },
+				MbOption { description: qsTr("Error"); value: 10 },
+//				MbOption { description: qsTr("Unknown"); value: 11 },
+				MbOption { description: qsTr("Shutdown"); value: 12 },
+				MbOption { description: qsTr("Updating"); value: 13 },
+				MbOption { description: qsTr("Standby"); value: 14 },
+				MbOption { description: qsTr("Going to run"); value: 15 },
+				MbOption { description: qsTr("Pre-Charging"); value: 16 },
+				MbOption { description: qsTr("Contactor check"); value: 17 }
+			]
+		}
+
+		MbItemBmsError {
+			description: qsTr("Error")
+			item.bind: service.path("/ErrorCode")
+			show: item.valid
+		}
+
+		MbItemRow {
+			description: qsTr("Battery")
+			values: [
+				MbTextBlock { item: dcVoltage; width: 90; height: 25 },
+				MbTextBlock { item: dcCurrent; width: 90; height: 25 },
+				MbTextBlock { item.bind: service.path("/Dc/0/Power"); width: 90; height: 25 }
+			]
+		}
+
+		MbItemValue {
+			id: soc
+			description: qsTr("State of charge")
+			item.bind: service.path("/Soc")
+			item.unit: "%"
+		}
+
+		MbItemValue {
+			description: qsTr("State of health")
+			item.bind: service.path("/Soh")
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Battery temperature")
+			item {
+				bind: service.path("/Dc/0/Temperature")
+				unit: "°C"
+			}
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Air temperature")
+			item {
+				bind: service.path("/AirTemperature")
+				unit: "°C"
+			}
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Starter voltage")
+			item.bind: service.path("/Dc/1/Voltage")
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Bus voltage")
+			item.bind: service.path("/BusVoltage")
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Top section voltage")
+			item {
+				value: midVoltage.valid && dcVoltage.valid ? dcVoltage.value - midVoltage.value : undefined
+				unit: "V"
+				decimals: 2
+			}
+			show: midVoltage.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Bottom section voltage")
+			item: midVoltage
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Mid-point deviation")
+			item.bind: service.path("/Dc/0/MidVoltageDeviation")
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Consumed AmpHours")
+			item.bind: service.path("/ConsumedAmphours")
+			show: item.valid
+		}
+
+		MbItemValue {
+			description: qsTr("Bus voltage")
+			item.bind: service.path("/BussVoltage")
+			show: item.valid
+		}
+
+		/* Time to go also needs to display infinite value */
+		MbItemTimeSpan {
+			description: qsTr("Time-to-go")
+			item.bind: service.path("/TimeToGo")
+			show: item.seen
+		}
+
+		MbItemOptions {
+			description: qsTr("Relay state")
+			bind: service.path("/Relay/0/State")
+			readonly: true
+			possibleValues:[
+				MbOption { description: qsTr("Off"); value: 0 },
+				MbOption { description: qsTr("On"); value: 1 }
+			]
+			show: valid
+		}
+
+		MbItemOptions {
+			description: qsTr("Alarm state")
+			bind: service.path("/Alarms/Alarm")
+			readonly: true
+			possibleValues:[
+				MbOption { description: qsTr("Ok"); value: 0 },
+				MbOption { description: qsTr("Alarm"); value: 1 }
+			]
+			show: valid
+		}
+
+		MbSubMenu {
+			description: qsTr("Details")
+			show: details.anyItemValid
+
+			property BatteryDetails details: BatteryDetails { id: details; bindPrefix: service.path("") }
+
+			subpage: Component {
+				PageBatteryDetails {
+					bindPrefix: service.path("")
+					details: details
+				}
+			}
+		}
+
+		MbSubMenu {
+			description: qsTr("Cell Voltages")
+			show: cell1.valid
+			subpage: Component {
+				PageBatteryCellVoltages {
+					bindPrefix: service.path("")
+				}				
+			}
+		}
+
+		MbSubMenu {
+			description: qsTr("Alarms")
+			subpage: Component {
+				PageBatteryAlarms {
+					title: qsTr("Alarms")
+					bindPrefix: service.path("")
+				}
+			}
+		}
+
+		MbSubMenu {
+			description: qsTr("History")
+			subpage: Component {
+				PageBatteryHistory {
+					title: qsTr("History")
+					bindPrefix: service.path("")
+				}
+			}
+			show: !isFiamm48TL
+		}
+
+		MbSubMenu {
+			id: settings
+			description: qsTr("Settings")
+			show: hasSettings.value === 1
+			subpage: Component {
+				PageBatterySettings {
+					title: settings.description
+					bindPrefix: service.path("")
+				}
+			}
+		}
+
+		MbSubMenu {
+			property VBusItem lastError: VBusItem { bind: service.path("/Diagnostics/LastErrors/1/Error") }
+
+			description: qsTr("Diagnostics")
+			subpage: Component {
+				PageLynxIonDiagnostics {
+					title: qsTr("Diagnostics")
+					bindPrefix: service.path("")
+				}
+			}
+			show: lastError.valid
+		}
+
+		MbSubMenu {
+			description: qsTr("Diagnostics")
+			subpage: Component {
+				Page48TlDiagnostics {
+					title: qsTr("Diagnostics")
+					bindPrefix: service.path("")
+				}
+			}
+			show: isFiamm48TL
+		}
+
+		MbSubMenu {
+			property VBusItem allowToCharge: VBusItem { bind: service.path("/Io/AllowToCharge") }
+
+			description: qsTr("IO")
+			subpage: Component {
+				PageLynxIonIo {
+					title: qsTr("IO")
+					bindPrefix: service.path("")
+				}
+			}
+			show: allowToCharge.valid
+		}
+
+		MbSubMenu {
+			property VBusItem nrOfBatteries: VBusItem { bind: service.path("/System/NrOfBatteries") }
+
+			description: qsTr("System")
+			subpage:  Component {
+				PageLynxIonSystem {
+					title: qsTr("System")
+					bindPrefix: service.path("")
+				}
+			}
+			show: nrOfBatteries.valid
+		}
+
+		MbSubMenu {
+			description: qsTr("Device")
+			subpage: Component {
+				PageDeviceInfo {
+					title: qsTr("Device")
+					bindPrefix: service.path("")
+				}
+			}
+		}
+
+		MbSubMenu {
+			property VBusItem cvl: VBusItem { bind: service.path("/Info/MaxChargeVoltage") }
+			property VBusItem ccl: VBusItem { bind: service.path("/Info/MaxChargeCurrent") }
+			property VBusItem dcl: VBusItem { bind: service.path("/Info/MaxDischargeCurrent") }
+
+			description: qsTr("Parameters")
+			show: cvl.valid || ccl.valid || dcl.valid
+			subpage: Component {
+				PageBatteryParameters {
+					title: qsTr("Parameters")
+					service: root.service
+				}
+			}
+		}
+
+		MbOK {
+			VBusItem {
+				id: redetect
+				bind: service.path("/Redetect")
+			}
+
+			description: qsTr("Redetect Battery")
+			value: qsTr("Press to redetect")
+			editable: redetect.value === 0
+			show: redetect.valid
+			cornerMark: false
+			writeAccessLevel: User.AccessUser
+			onClicked: {
+				redetect.setValue(1)
+				toast.createToast(qsTr("Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect."), 10000);
+			}
+		}
+	}
+}

--- a/etc/dbus-serialbattery/qml/PageBatteryCellVoltages.qml
+++ b/etc/dbus-serialbattery/qml/PageBatteryCellVoltages.qml
@@ -1,0 +1,94 @@
+import QtQuick 1.1
+import com.victron.velib 1.0
+
+MbPage {
+	id: root
+	property string bindPrefix
+	property VBusItem _b1: VBusItem { bind: service.path("/Balances/Cell1") }
+	property VBusItem _b2: VBusItem { bind: service.path("/Balances/Cell2") }
+	property VBusItem _b3: VBusItem { bind: service.path("/Balances/Cell3") }
+	property VBusItem _b4: VBusItem { bind: service.path("/Balances/Cell4") }
+	property VBusItem _b5: VBusItem { bind: service.path("/Balances/Cell5") }
+	property VBusItem _b6: VBusItem { bind: service.path("/Balances/Cell6") }
+	property VBusItem _b7: VBusItem { bind: service.path("/Balances/Cell7") }
+	property VBusItem _b8: VBusItem { bind: service.path("/Balances/Cell8") }
+	property VBusItem _b9: VBusItem { bind: service.path("/Balances/Cell9") }
+	property VBusItem _b10: VBusItem { bind: service.path("/Balances/Cell10") }
+	property VBusItem _b11: VBusItem { bind: service.path("/Balances/Cell11") }
+	property VBusItem _b12: VBusItem { bind: service.path("/Balances/Cell12") }
+	property VBusItem _b13: VBusItem { bind: service.path("/Balances/Cell13") }
+	property VBusItem _b14: VBusItem { bind: service.path("/Balances/Cell14") }
+	property VBusItem _b15: VBusItem { bind: service.path("/Balances/Cell15") }
+	property VBusItem _b16: VBusItem { bind: service.path("/Balances/Cell16") }
+	property string c1: _b1.valid && _b1.text == "1" ? "#ff0000" : "#ddd"
+	property string c2: _b2.valid && _b2.text == "1" ? "#ff0000" : "#ddd"
+	property string c3: _b3.valid && _b3.text == "1" ? "#ff0000" : "#ddd"
+	property string c4: _b4.valid && _b4.text == "1" ? "#ff0000" : "#ddd"
+	property string c5: _b5.valid && _b5.text == "1" ? "#ff0000" : "#ddd"
+	property string c6: _b6.valid && _b6.text == "1" ? "#ff0000" : "#ddd"
+	property string c7: _b7.valid && _b7.text == "1" ? "#ff0000" : "#ddd"
+	property string c8: _b8.valid && _b8.text == "1" ? "#ff0000" : "#ddd"
+	property string c9: _b9.valid && _b9.text == "1" ? "#ff0000" : "#ddd"
+	property string c10: _b10.valid && _b10.text == "1" ? "#ff0000" : "#ddd"
+	property string c11: _b11.valid && _b11.text == "1" ? "#ff0000" : "#ddd"
+	property string c12: _b12.valid && _b12.text == "1" ? "#ff0000" : "#ddd"
+	property string c13: _b13.valid && _b13.text == "1" ? "#ff0000" : "#ddd"
+	property string c14: _b14.valid && _b14.text == "1" ? "#ff0000" : "#ddd"
+	property string c15: _b15.valid && _b15.text == "1" ? "#ff0000" : "#ddd"
+	property string c16: _b16.valid && _b16.text == "1" ? "#ff0000" : "#ddd"
+	title: service.description + " | Cell Voltages"
+
+	model: VisualItemModel {
+
+		MbItemRow {
+			description: qsTr("Cells Sum")
+			values: [
+				MbTextBlock { item { bind: service.path("/Voltages/Sum") } width: 70; height: 25 }
+			]
+		}
+		MbItemRow {
+			description: qsTr("Cells (Min/Max/Diff)")
+			values: [
+				MbTextBlock { item { bind: service.path("/System/MinCellVoltage") } width: 70; height: 25 },
+				MbTextBlock { item { bind: service.path("/System/MaxCellVoltage") } width: 70; height: 25 },
+				MbTextBlock { item { bind: service.path("/Voltages/Diff") } width: 70; height: 25 }
+			]
+		}
+		MbItemRow {
+			description: qsTr("Cells (1/2/3/4)")
+			values: [
+				MbTextBlock { item { bind: service.path("/Voltages/Cell1") } width: 70; height: 25; color: c1 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell2") } width: 70; height: 25; color: c2 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell3") } width: 70; height: 25; color: c3 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell4") } width: 70; height: 25; color: c4 }
+			]
+		}
+		MbItemRow {
+			description: qsTr("Cells (5/6/7/8)")
+			values: [
+				MbTextBlock { item { bind: service.path("/Voltages/Cell5") } width: 70; height: 25; color: c5 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell6") } width: 70; height: 25; color: c6 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell7") } width: 70; height: 25; color: c7 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell8") } width: 70; height: 25; color: c8 }
+			]
+		}
+		MbItemRow {
+			description: qsTr("Cells (9/10/11/12)")
+			values: [
+				MbTextBlock { item { bind: service.path("/Voltages/Cell9") } width: 70; height: 25; color: c9 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell10") } width: 70; height: 25; color: c10 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell11") } width: 70; height: 25; color: c11 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell12") } width: 70; height: 25; color: c12 }
+			]
+		}
+		MbItemRow {
+			description: qsTr("Cells (13/14/15/16)")
+			values: [
+				MbTextBlock { item { bind: service.path("/Voltages/Cell13") } width: 70; height: 25; color: c13 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell14") } width: 70; height: 25; color: c14 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell15") } width: 70; height: 25; color: c15 },
+				MbTextBlock { item { bind: service.path("/Voltages/Cell16") } width: 70; height: 25; color: c16 }
+			]
+		}
+	}
+}


### PR DESCRIPTION
Response to issue : Show all Cells within the battery on console detail screen #68
Added publishing of cell voltages and cell balancing to dbus.
Added qml files for visualisation of cell voltages
qml files are installed by running "sh /data/etc/dbus-serialbattery/installqml.sh"
WARNING! - by running the "installqml.sh" is the existing file "/opt/victronenergy/gui/qml/PageBattery.qml" overwritten
![Venus - Cell Voltages](https://user-images.githubusercontent.com/18731995/152356645-187e6c45-ea52-46b1-a0a3-3cad6c84019c.png)
The etc/dbus-serialbattery/qml/PageBatteryCellVoltages.qml file is for 16 batteries