### PR TITLE
Add support for cell voltages and TimeToSoC items on dbus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 venv
 venus-data.tar.gz
 BMS-trials
-etc/.DS_Store
-etc/dbus-serialbattery/.DS_Store
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 venv
 venus-data.tar.gz
 BMS-trials
+etc/.DS_Store
+etc/dbus-serialbattery/.DS_Store

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -99,6 +99,10 @@ class Battery(object):
         # Start with the current values
 
         # Change depending on the SOC values
+        if self.soc is None:
+            # Prevent serialbattery from terminating on error
+            return False
+            
         if self.soc > 99:
             self.control_allow_charge = False
         else:

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -74,9 +74,8 @@ class Daly(Battery):
         # Ensure data received is valid
         crntMinValid = -(MAX_BATTERY_DISCHARGE_CURRENT * 2.1)
         crntMaxValid = (MAX_BATTERY_CURRENT * 1.3)
-        validData = False
         triesValid = 3
-        while validData is False and triesValid > 0:
+        while triesValid > 0:
             soc_data = False
             # Try up to 3 times to get data. This greatly increases soc_data collection with Daly
             triesData = 3
@@ -89,18 +88,16 @@ class Daly(Battery):
                 return False
 
             voltage, tmp, current, soc = unpack_from('>hhhh', soc_data)
-            soc /= 10
-            voltage /= 10
             current = ((current - self.CURRENT_ZERO_CONSTANT) / -10 * INVERT_CURRENT_MEASUREMENT)
             if crntMinValid < current < crntMaxValid:
-                validData = True
+                self.voltage = (voltage / 10)
+                self.current = current
+                self.soc = (soc / 10)
+                return True
+                
             triesValid -= 1
 
-        if validData is True:
-            self.voltage = voltage
-            self.current = current
-            self.soc = soc
-        return True
+        return False
 
     def read_alarm_data(self):
         alarm_data = self.read_serial_data_daly(self.command_alarm)

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -19,6 +19,7 @@ class Daly(Battery):
         self.type = self.BATTERYTYPE
     # command bytes [StartFlag=A5][Address=40][Command=94][DataLength=8][8x zero bytes][checksum]
     command_base = b"\xA5\x40\x94\x08\x00\x00\x00\x00\x00\x00\x00\x00\x81"
+    cellvolt_buffer = b"\xA5\x40\x94\x08\x00\x00\x00\x00\x00\x00\x00\x00\x82\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     command_soc = b"\x90"
     command_minmax_cell_volts = b"\x91"
     command_minmax_temp = b"\x92"
@@ -44,6 +45,8 @@ class Daly(Battery):
 
     def refresh_data(self):
         result = self.read_soc_data()
+        result = result and self.read_alarm_data()
+        result = result and self.read_cells_volts()
         result = result and self.read_cell_voltage_range_data()
         result = result and self.read_temperature_range_data()
         result = result and self.read_fed_data()
@@ -54,6 +57,7 @@ class Daly(Battery):
         status_data = self.read_serial_data_daly(self.command_status)
         # check if connection success
         if status_data is False:
+            logger.warning("read_status_data")
             return False
 
         self.cell_count, self.temp_sensors, self.charger_connected, self.load_connected, \
@@ -67,9 +71,15 @@ class Daly(Battery):
         return True
 
     def read_soc_data(self):
-        soc_data = self.read_serial_data_daly(self.command_soc)
+        soc_data = False
+        # Try up to 3 times to get data. This greatly increases soc_data collection with Daly
+        tries = 3
+        while soc_data is False and tries > 0:
+            soc_data = self.read_serial_data_daly(self.command_soc)
+            tries -= 1
         # check if connection success
         if soc_data is False:
+            logger.warning("read_soc_data")
             return False
 
         voltage, tmp, current, soc = unpack_from('>hhhh', soc_data)
@@ -78,10 +88,146 @@ class Daly(Battery):
         self.soc = soc / 10
         return True
 
+    def read_alarm_data(self):
+        alarm_data = self.read_serial_data_daly(self.command_alarm)
+        # check if connection success
+        if alarm_data is False:
+            logger.warning("read_alarm_data")
+            return False
+
+        al_volt, al_temp, al_crnt_soc, al_diff, \
+            al_mos, al_misc1, al_misc2, al_fault = unpack_from('>bbbbbbbb', alarm_data)
+
+        if al_volt & 48:
+            # High voltage levels - Alarm
+            self.voltage_high = 2            
+        elif al_volt & 15:
+            # High voltage Warning levels - Pre-alarm
+            self.voltage_high = 1
+        else:
+            self.voltage_high = 0
+
+        if al_volt & 128:
+            # Low voltage level - Alarm
+            self.voltage_low = 2
+        elif al_volt & 64:
+            # Low voltage Warning level - Pre-alarm
+            self.voltage_low = 1
+        else:
+            self.voltage_low = 0
+
+        if al_temp & 2:
+            # High charge temp - Alarm
+            self.temp_high_charge = 2            
+        elif al_temp & 1:
+            # High charge temp - Pre-alarm
+            self.temp_high_charge = 1
+        else:
+            self.temp_high_charge = 0
+
+        if al_temp & 8:
+            # Low charge temp - Alarm
+            self.temp_low_charge = 2            
+        elif al_temp & 4:
+            # Low charge temp - Pre-alarm
+            self.temp_low_charge = 1
+        else:
+            self.temp_low_charge = 0
+
+
+        if al_temp & 32:
+            # High discharge temp - Alarm
+            self.temp_high_discharge = 2            
+        elif al_temp & 16:
+            # High discharge temp - Pre-alarm
+            self.temp_high_discharge = 1
+        else:
+            self.temp_high_discharge = 0
+
+        if al_temp & 128:
+            # Low discharge temp - Alarm
+            self.temp_low_discharge = 2            
+        elif al_temp & 64:
+            # Low discharge temp - Pre-alarm
+            self.temp_low_discharge = 1
+        else:
+            self.temp_low_discharge = 0
+
+        #if al_crnt_soc & 2:
+        #    # High charge current - Alarm
+        #    self.current_over = 2            
+        #elif al_crnt_soc & 1:
+        #    # High charge current - Pre-alarm
+        #    self.current_over = 1
+        #else:
+        #    self.current_over = 0
+
+        #if al_crnt_soc & 8:
+        #    # High discharge current - Alarm
+        #    self.current_over = 2            
+        #elif al_crnt_soc & 4:
+        #    # High discharge current - Pre-alarm
+        #    self.current_over = 1
+        #else:
+        #    self.current_over = 0
+
+        if al_crnt_soc & 2 or al_crnt_soc & 8:
+            # High charge/discharge current - Alarm
+            self.current_over = 2            
+        elif al_crnt_soc & 1 or al_crnt_soc & 4:
+            # High charge/discharge current - Pre-alarm
+            self.current_over = 1
+        else:
+            self.current_over = 0
+
+        if al_crnt_soc & 128:
+            # Low SoC - Alarm
+            self.soc_low = 2
+        elif al_crnt_soc & 64:
+            # Low SoC Warning level - Pre-alarm
+            self.soc_low = 1
+        else:
+            self.soc_low = 0
+        
+        return True
+
+    def read_cells_volts(self):
+        if self.cell_count is not None:
+            buffer = bytearray(self.cellvolt_buffer)
+            buffer[1] = self.command_address[0]   # Always serial 40 or 80
+            buffer[2] = self.command_cell_volts[0]
+
+            maxFrame = (int(self.cell_count / 3) + 1)
+            lenFixed = (maxFrame * 12)
+
+            cells_volts_data = read_serial_data(buffer, self.port, self.baud_rate, self.LENGTH_POS, self.LENGTH_CHECK, lenFixed)
+            if cells_volts_data is False:
+                logger.warning("read_cells_volts")
+                return False
+
+            frameCell = [0, 0, 0]
+            lowMin = (MIN_CELL_VOLTAGE / 2)
+            cellnum = 0
+            frame = 0
+            while frame >= 0 and frame < maxFrame and cellnum < self.cell_count:
+                startPos = ((frame * 12) + 4)
+                logger.warning('cell: ' + str(cellnum) + ', startPos: ' + str(startPos) + ', frame: ' + str(frame))
+                if frame > 0 and frame < 16:
+                    startPos += 1
+                frame, frameCell[0], frameCell[1], frameCell[2], reserved = unpack_from('>bhhhb', cells_volts_data, startPos)
+                for idx in range(3):
+                    if len(self.cells) == cellnum:
+                        self.cells.append(Cell(True))
+                    self.cells[cellnum].voltage = None if frameCell[idx] < lowMin else (frameCell[idx] / 1000)
+                    cellnum += 1
+
+        return True
+
     def read_cell_voltage_range_data(self):
         minmax_data = self.read_serial_data_daly(self.command_minmax_cell_volts)
         # check if connection success
         if minmax_data is False:
+            logger.warning("read_cell_voltage_range_data")
             return False
 
         cell_max_voltage,self.cell_max_no,cell_min_voltage, self.cell_min_no = unpack_from('>hbhb', minmax_data)
@@ -97,6 +243,7 @@ class Daly(Battery):
         minmax_data = self.read_serial_data_daly(self.command_minmax_temp)
         # check if connection success
         if minmax_data is False:
+            logger.warning("read_temperature_range_data")
             return False
 
         max_temp,max_no,min_temp, min_no = unpack_from('>bbbb', minmax_data)
@@ -108,6 +255,7 @@ class Daly(Battery):
         fed_data = self.read_serial_data_daly(self.command_fet)
         # check if connection success
         if fed_data is False:
+            logger.warning("read_fed_data")
             return False
 
         status, self.charge_fet, self.discharge_fet, bms_cycles, capacity_remain = unpack_from('>b??BL', fed_data)

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -95,11 +95,11 @@ class DbusHelper:
         # Create Cell voltage items
         for num in range(self.battery.cell_count):
             num += 1
-            self._dbusservice.add_path('/Cell/' + num + '/Voltage', None, writeable=True, gettextcallback=lambda p, v: "{:0.2f}".format(v))
+            self._dbusservice.add_path('/Cell/' + str(num) + '/Voltage', None, writeable=True, gettextcallback=lambda p, v: "{:0.2f}".format(v))
 
         # Create TimeToSoC items
         for num in [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0]:
-            self._dbusservice.add_path('/TimeToSoC/' + num, None, writeable=True)
+            self._dbusservice.add_path('/TimeToSoC/' + str(num), None, writeable=True)
 
         # Create SOC, DC and System items
         self._dbusservice.add_path('/Soc', None, writeable=True)

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -92,6 +92,15 @@ class DbusHelper:
         # Not used at this stage
         # self._dbusservice.add_path('/System/MinTemperatureCellId', None, writeable=True)
         # self._dbusservice.add_path('/System/MaxTemperatureCellId', None, writeable=True)
+        # Create Cell voltage items
+        for num in range(self.battery.cell_count):
+            num += 1
+            self._dbusservice.add_path('/Cell/' + num + '/Voltage', None, writeable=True, gettextcallback=lambda p, v: "{:0.2f}".format(v))
+
+        # Create TimeToSoC items
+        for num in [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0]:
+            self._dbusservice.add_path('/TimeToSoC/' + num, None, writeable=True)
+
         # Create SOC, DC and System items
         self._dbusservice.add_path('/Soc', None, writeable=True)
         self._dbusservice.add_path('/Dc/0/Voltage', None, writeable=True, gettextcallback=lambda p, v: "{:2.2f}V".format(v))
@@ -163,6 +172,66 @@ class DbusHelper:
             loop.quit()
 
     def publish_dbus(self):
+        # Update Cell voltage items
+        for num in range(self.battery.cell_count):
+            cellVolts = None if num >= len(self.battery.cells) or self.battery.cells[num] is None else self.battery.cells[num].voltage
+            num += 1
+            self._dbusservice['/Cell/' + str(num) + '/Voltage'] = cellVolts
+
+        # Update TimeToSoC items
+        if self.battery.capacity is not None and self.battery.current:
+            onePrctAmps = (self.battery.capacity / 100)
+            # Charging of Discharging
+            if self.battery.current > 0:
+                crntPrctPerHr = (self.battery.current / onePrctAmps)
+            else:
+                crntPrctPerHr = -(self.battery.current / onePrctAmps)
+            crntPrctPerSec = (crntPrctPerHr / 3600)
+
+            for num in [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0]:
+                # Charging of Discharging
+                if self.battery.current > 0:
+                    diffSoc = (num - self.battery.soc)
+                else:
+                    diffSoc = (self.battery.soc - num) 
+                ttgStr = None
+                if self.battery.soc != num and diffSoc > 0:
+                    ttg = 0
+                    ttgD = 0
+                    ttgH = 0
+                    ttgM = 0
+                    ttgS = 0
+                    ttgStr = ""
+                    ttg = int(diffSoc / crntPrctPerSec)
+                    ttgS = ttg
+                    if ttgS >= 86400:
+                        ttgD = int(ttgS / 86400)
+                        ttgS -= (ttgD * 86400)
+                    if ttgS >= 3600:
+                        ttgH = int(ttgS / 3600)
+                        ttgS -= (ttgH * 3600)
+                    if ttgS >= 60:
+                        ttgM = int(ttgS / 60)
+                        ttgS -= (ttgM * 60)
+                    ttgS = round(ttgS, 1)
+                    if ttg >= 86400:
+                        ttgStr += str(ttgD) + "d "
+                        if ttgH < 10:
+                            ttgStr += "0"
+                    if ttg >= 3600:
+                        ttgStr += str(ttgH) + ":"
+                        if ttgM < 10:
+                            ttgStr += "0"
+                    if ttg >= 60:
+                        ttgStr += str(ttgM) + ":"
+                        if ttgS < 10:
+                            ttgStr += "0"
+                    ttgStr += str(ttgS)
+                self._dbusservice['/TimeToSoC/' + str(num)] = ttgStr
+        else:
+            for num in [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0]:
+                self._dbusservice['/TimeToSoC/' + str(num)] = None
+
         # Update SOC, DC and System items
         self._dbusservice['/System/NrOfCellsPerBattery'] = self.battery.cell_count
         self._dbusservice['/Soc'] = round(self.battery.soc, 2)

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -21,6 +21,8 @@ MAX_CELL_VOLTAGE = 3.45
 # battery Current limits
 MAX_BATTERY_CURRENT = 50.0
 MAX_BATTERY_DISCHARGE_CURRENT = 60.0
+# Battery capacity (amps)
+BATTERY_CAPACITY = 50
 # Invert Battery Current. Default non-inverted. Set to -1 to invert
 INVERT_CURRENT_MEASUREMENT = 1
 


### PR DESCRIPTION
-battery.py
    Help prevent terminating when BMS doesn't return valid SoC data.
- utils.py
    Add config variable: BATTERY_CAPACITY
-dbushelper.py
    Add support for individual cell voltages.
    Add support for TimeToSoC for 5% SoC.
        All times will be positive regardless of whether charge/discharge.
        When charging and SoC is >= to a SoC percentage that percentage value will be None (or "-").
         When discharging and SoC is <= to a SoC percentage that percentage value will be None (or "-").
        If not charging or discharging all TimeToSoC will be None (or "-").
-daly.py
    Improve reliability of data read from Daly BMS
    Add cellvolt_buffer to read cell voltages and to accommodate up to 48 cells (Daly current max supported cells).
    read_soc_data attempts 3 times to read soc_data from Daly before failing.  This greatly increases the read reliability of some Daly devices.
    Add function read_alarm_data for most previously defined dbus Alarms items.
    Add function read_cells_volts to read read all individual cell voltages for up to 48 cells. Tested only with 4 cell BMS.
    Add logger.warning messages to understand which dataset read failed.