### PR TITLE
Time to soc

### DIFF
--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -11,7 +11,6 @@ from vedbus import VeDbusService
 from settingsdevice import SettingsDevice
 import battery
 from utils import *
-from datetime import timedelta
 
 def get_bus():
     return dbus.SessionBus() if 'DBUS_SESSION_BUS_ADDRESS' in os.environ else dbus.SystemBus()

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -25,6 +25,24 @@ MAX_BATTERY_DISCHARGE_CURRENT = 60.0
 BATTERY_CAPACITY = 50
 # Invert Battery Current. Default non-inverted. Set to -1 to invert
 INVERT_CURRENT_MEASUREMENT = 1
+# Set of SoC percentages to report on dbus. The more you specify the more it will impact system performance.
+#TIME_TO_SOC_POINTS = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0]		# Every 5% SoC
+#TIME_TO_SOC_POINTS = []	                # No data set
+TIME_TO_SOC_POINTS = [100, 95, 90, 85, 75, 50, 25, 20, 10, 0]
+# Specify TimeToSoc value type:
+#TIME_TO_SOC_VALUE_TYPE = 1        # Seconds
+#TIME_TO_SOC_VALUE_TYPE = 2        # Time string HH:MN:SC
+TIME_TO_SOC_VALUE_TYPE = 3        # Both Seconds and time str "<seconds> [days, HR:MN:SC]"
+# Specify how many loop cycles between each TimeToSoc updates
+TIME_TO_SOC_LOOP_CYCLES = 5
+# Include TimeToSoC points when moving away from the SoC point.  These will be as negative time. Disabling this improves performance slightly.
+TIME_TO_SOC_INC_FROM = False
+#TIME_TO_SOC_INC_FROM = True
+# Select the format of cell data presented on dbus.
+BATTERY_CELL_DATA_FORMAT = 1                   # Format: /Voltages/Cell# (also available for display on Remote Console)
+#BATTERY_CELL_DATA_FORMAT = 2                   # Format: /Cell/#/Volts
+#BATTERY_CELL_DATA_FORMAT = 3                   # Both formats 1 and 2
+
 
 def is_bit_set(tmp):
     return False if tmp == zero_char else True


### PR DESCRIPTION
battery.py
-Add variable time_to_soc_update to support updating TimeToSoC values every TIME_TO_SOC_LOOP_CYCLES
-Modified function get_timetosoc to receive pre-calculated crntPrctPerSec and produce user configured TimeToSoC format via TIME_TO_SOC_VALUE_TYPE and results of negative SoC times (when moving away from an SoC point) via user configured TIME_TO_SOC_INC_FROM

daly.py
-Change poll_interval from 2000 to 1000 to allow more frequent calls to refresh_data given smaller data set collection with the introduction of poll_step method
-Add variable poll_step to hold step number between calls to refresh_data
-Add support for refreshing only specific data sets during each refresh_data cycle
-Disabled logger call while reading cell voltages

dbushelper.py
-Add support for user configured battery cell data format via BATTERY_CELL_DATA_FORMAT
-Add support for user configured TimeToSoC points via TIME_TO_SOC_POINTS instead of fixed points
-Add support for updating TimeToSoC point values only every TIME_TO_SOC_LOOP_CYCLES instead of all publish_dbus cycles

utils.py
-Add user config variables to control TimeToSoC functions and battery cell data formats, along with info/examples of the purpose for the variables
