### PR TITLE
fix single cell voltages for Daly BMS

### DIFF
--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -60,8 +60,7 @@ class Daly(Battery):
             result = result and self.read_fed_data(ser)
             if self.poll_step == 0:
                 # This must be listed in step 0 as get_min_cell_voltage and get_max_cell_voltage in battery.py needs it at first cycle for publish_dbus in dbushelper.py
-                #result = result and self.read_cell_voltage_range_data(ser)
-                a = 1
+                result = result and self.read_cell_voltage_range_data(ser)
             elif self.poll_step == 1:
                 result = result and self.read_alarm_data(ser)
             elif self.poll_step == 2:

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -64,8 +64,8 @@ class Daly(Battery):
             elif self.poll_step == 1:
                 result = result and self.read_alarm_data(ser)
             elif self.poll_step == 2:
-            #     result = result and self.read_cells_volts(ser)
-            # elif self.poll_step == 3:
+                result = result and self.read_cells_volts(ser)
+            elif self.poll_step == 3:
                 result = result and self.read_temperature_range_data(ser)
             #else:          # A placeholder to remind this is the last step. Add any additional steps before here
                 # This is last step so reset poll_step

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -60,7 +60,8 @@ class Daly(Battery):
             result = result and self.read_fed_data(ser)
             if self.poll_step == 0:
                 # This must be listed in step 0 as get_min_cell_voltage and get_max_cell_voltage in battery.py needs it at first cycle for publish_dbus in dbushelper.py
-                result = result and self.read_cell_voltage_range_data(ser)
+                #result = result and self.read_cell_voltage_range_data(ser)
+                a = 1
             elif self.poll_step == 1:
                 result = result and self.read_alarm_data(ser)
             elif self.poll_step == 2:
@@ -239,17 +240,19 @@ class Daly(Battery):
             lowMin = (MIN_CELL_VOLTAGE / 2)
             cellnum = 0
             frame = 0
-            while frame >= 0 and frame < maxFrame and cellnum < self.cell_count:
-                startPos = ((frame * 12) + 4)
-                #logger.debug('cell: ' + str(cellnum) + ', startPos: ' + str(startPos) + ', frame: ' + str(frame))
-                if frame > 0 and frame < 16:
-                    startPos += 1
-                frame, frameCell[0], frameCell[1], frameCell[2], reserved = unpack_from('>bhhhb', cells_volts_data, startPos)
-                for idx in range(3):
+
+            bufIdx = 0
+            while bufIdx < len(cells_volts_data) - 4: # we at least need 4 bytes to extract the identifiers
+                b1, b2, b3, b4 = unpack_from('>BBBB', cells_volts_data, bufIdx)
+                if b1 == 0xA5 and b2 == 0x01 and b3 == 0x95 and b4 == 0x08:
+                  frame, frameCell[0], frameCell[1], frameCell[2] = unpack_from('>Bhhh', cells_volts_data, bufIdx + 4)
+                  for idx in range(3):
                     if len(self.cells) == cellnum:
                         self.cells.append(Cell(True))
                     self.cells[cellnum].voltage = None if frameCell[idx] < lowMin else (frameCell[idx] / 1000)
                     cellnum += 1
+                  bufIdx += 10 # BBBBBhhh -> 11 byte
+                bufIdx += 1
 
         return True
 


### PR DESCRIPTION
Fixes https://github.com/Louisvdw/dbus-serialbattery/issues/160

Before:
```
@4000000062e2e44d24ed02b4 INFO:SerialBattery:cell: 0, startPos: 4, frame: 0, cell count: 16
@4000000062e2e44d24f61304 INFO:SerialBattery:1: 3350, 2: 3346, 3: 3340
@4000000062e2e44d25017514 INFO:SerialBattery:cell: 3, startPos: 16, frame: 1, cell count: 16
@4000000062e2e44d250d63c4 INFO:SerialBattery:1: 3350, 2: 3355, 3: 3362
@4000000062e2e44d251dbb5c INFO:SerialBattery:cell: 6, startPos: 28, frame: 2, cell count: 16
@4000000062e2e44d252817b4 INFO:SerialBattery:1: 781, 2: 5901, 3: 6669
```

After:
```
@4000000062e2e80222f70eb4 INFO:SerialBattery:cell: 0, startPos: 4, frame: 0, cell count: 16
@4000000062e2e8022300e254 INFO:SerialBattery:frame: 1, 1: 3350, 2: 3346, 3: 3340
@4000000062e2e802230b69a4 INFO:SerialBattery:cell: 3, startPos: 16, frame: 1, cell count: 16
@4000000062e2e8022314df84 INFO:SerialBattery:frame: 2, 1: 3350, 2: 3355, 3: 3361
@4000000062e2e802231ef58c INFO:SerialBattery:cell: 6, startPos: 28, frame: 2, cell count: 16
@4000000062e2e80223285fb4 INFO:SerialBattery:frame: 3, 1: 3351, 2: 3354, 3: 3340
@4000000062e2e80223324eac INFO:SerialBattery:cell: 9, startPos: 40, frame: 3, cell count: 16
@4000000062e2e802233db4a4 INFO:SerialBattery:frame: 4, 1: 3340, 2: 3340, 3: 3344
@4000000062e2e802234891e4 INFO:SerialBattery:cell: 12, startPos: 52, frame: 4, cell count: 16
@4000000062e2e8022352984c INFO:SerialBattery:frame: 5, 1: 3340, 2: 3338, 3: 3339
@4000000062e2e802235cdd34 INFO:SerialBattery:cell: 15, startPos: 64, frame: 5, cell count: 16
@4000000062e2e80223669964 INFO:SerialBattery:frame: 6, 1: 3340, 2: 3338, 3: 3339
```

Looks like the returned data can not reliably be parsed by just looking at a specific index, rather the identifier bytes need to be checked correctly, and then the following bytes should be used for cell voltages.