### PR TITLE
Properly get cell number based on message frame for Daly and filter invalid values

### DIFF
--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -229,7 +229,7 @@ class Daly(Battery):
             buffer[2] = self.command_cell_volts[0]
 
             maxFrame = math.ceil(self.cell_count / 3)
-            lenFixed = (maxFrame * 13) # 0xA5, 0x01, 0x95, 0x08 + 1 byte frame + 8 byte data
+            lenFixed = (maxFrame * 12) # 0xA5, 0x01, 0x95, 0x08 + 1 byte frame + 6 byte data + 1byte reserved
 
             cells_volts_data = read_serialport_data(ser, buffer, self.LENGTH_POS, self.LENGTH_CHECK, lenFixed)
             if cells_volts_data is False:

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -248,7 +248,9 @@ class Daly(Battery):
                   for idx in range(3):
                     if len(self.cells) == cellnum:
                         self.cells.append(Cell(True))
-                    self.cells[cellnum].voltage = None if frameCell[idx] < lowMin else (frameCell[idx] / 1000)
+                    cellVoltage = frameCell[idx] / 1000
+                    self.cells[cellnum].voltage = None if cellVoltage < lowMin else cellVoltage
+
                     cellnum += 1
                   bufIdx += 10 # BBBBBhhh -> 11 byte
                 bufIdx += 1

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from battery import Protection, Battery, Cell
 from utils import *
 from struct import *
-import math
 
 class Daly(Battery):
 

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -227,7 +227,7 @@ class Daly(Battery):
             buffer[1] = self.command_address[0]   # Always serial 40 or 80
             buffer[2] = self.command_cell_volts[0]
 
-            maxFrame = math.ceil(self.cell_count / 3)
+            (int(self.cell_count / 3) + 1)
             lenFixed = (maxFrame * 12) # 0xA5, 0x01, 0x95, 0x08 + 1 byte frame + 6 byte data + 1byte reserved
 
             cells_volts_data = read_serialport_data(ser, buffer, self.LENGTH_POS, self.LENGTH_CHECK, lenFixed)

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -227,7 +227,7 @@ class Daly(Battery):
             buffer[1] = self.command_address[0]   # Always serial 40 or 80
             buffer[2] = self.command_cell_volts[0]
 
-            (int(self.cell_count / 3) + 1)
+            maxFrame = (int(self.cell_count / 3) + 1)
             lenFixed = (maxFrame * 12) # 0xA5, 0x01, 0x95, 0x08 + 1 byte frame + 6 byte data + 1byte reserved
 
             cells_volts_data = read_serialport_data(ser, buffer, self.LENGTH_POS, self.LENGTH_CHECK, lenFixed)

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -64,8 +64,8 @@ class Daly(Battery):
             elif self.poll_step == 1:
                 result = result and self.read_alarm_data(ser)
             elif self.poll_step == 2:
-                result = result and self.read_cells_volts(ser)
-            elif self.poll_step == 3:
+                #result = result and self.read_cells_volts(ser)
+            #elif self.poll_step == 3:
                 result = result and self.read_temperature_range_data(ser)
             #else:          # A placeholder to remind this is the last step. Add any additional steps before here
                 # This is last step so reset poll_step

--- a/etc/dbus-serialbattery/daly.py
+++ b/etc/dbus-serialbattery/daly.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from battery import Protection, Battery, Cell
 from utils import *
 from struct import *
+import math
 
 class Daly(Battery):
 
@@ -227,8 +228,8 @@ class Daly(Battery):
             buffer[1] = self.command_address[0]   # Always serial 40 or 80
             buffer[2] = self.command_cell_volts[0]
 
-            maxFrame = (int(self.cell_count / 3) + 1)
-            lenFixed = (maxFrame * 12)
+            maxFrame = math.ceil(self.cell_count / 3)
+            lenFixed = (maxFrame * 13) # 0xA5, 0x01, 0x95, 0x08 + 1 byte frame + 8 byte data
 
             cells_volts_data = read_serialport_data(ser, buffer, self.LENGTH_POS, self.LENGTH_CHECK, lenFixed)
             if cells_volts_data is False:


### PR DESCRIPTION
the check did not filter out incorrect values before.

related to https://github.com/Louisvdw/dbus-serialbattery/issues/165