### PR TITLE
VenusOS 2.91 RW Mount on /

### DIFF
--- a/etc/dbus-serialbattery/reinstalllocal.sh
+++ b/etc/dbus-serialbattery/reinstalllocal.sh
@@ -3,6 +3,10 @@
 DRIVER=/opt/victronenergy/dbus-serialbattery
 RUN=/opt/victronenergy/service-templates/dbus-serialbattery
 OLD=/opt/victronenergy/service/dbus-serialbattery
+
+#/dev/mmcblk1p3 mountpoint / was made read only in 2.91 release
+mount -o remount,rw /dev/mmcblk1p3 /
+
 if [ -d "$DRIVER" ]; then
   if [ -L "$DRIVER" ]; then
     # Remove old SymLink.


### PR DESCRIPTION
Update reinstalllocal.sh with Read/Write remount for /

Now that / is Read Only, scripts were not running, this is a fix for that.