### PR TITLE
Fix invalid reference to deprecated Revov. Fix #364

### DIFF
--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -22,7 +22,6 @@ from ant import Ant
 from jkbms import Jkbms
 from sinowealth import Sinowealth
 from renogy import Renogy
-from revov import Revov
 from ecs import Ecs
 from lifepower import Lifepower
 #from mnb import MNB


### PR DESCRIPTION
dbus-serialbattery.py still had reference to deprecated Revov BMS, although the files are not included in the build.