### PR TITLE
Fixes to cell voltage, temp and version

### DIFF
--- a/etc/dbus-serialbattery/lifepower.py
+++ b/etc/dbus-serialbattery/lifepower.py
@@ -5,8 +5,8 @@ from utils import *
 from struct import *
 import re
 
-class Lifepower(Battery):
 
+class Lifepower(Battery):
     def __init__(self, port, baud):
         super(Lifepower, self).__init__(port, baud)
         self.type = self.BATTERYTYPE
@@ -39,16 +39,14 @@ class Lifepower(Battery):
             self.hardware_version = re.sub(
                 r"[^a-zA-Z0-9-._ ]",
                 "",
-                str(hardware_version, encoding='utf-8', errors='ignore'),
+                str(hardware_version, encoding="utf-8", errors="ignore"),
             )
             logger.info("Hardware Version:" + self.hardware_version)
 
         version = self.read_serial_data_eg4(self.command_firmware_version)
         if version:
             self.version = re.sub(
-                r"[^a-zA-Z0-9-._ ]",
-                "",
-                str(version, encoding='utf-8', errors='ignore')
+                r"[^a-zA-Z0-9-._ ]", "", str(version, encoding="utf-8", errors="ignore")
             )
             logger.info("Firmware Version:" + self.version)
 
@@ -83,7 +81,7 @@ class Lifepower(Battery):
             group_payload = status_data[i + 2 : end]
             groups.append(
                 [
-                    unpack_from('>H', group_payload, i)[0]
+                    unpack_from(">H", group_payload, i)[0]
                     for i in range(0, len(group_payload), 2)
                 ]
             )
@@ -109,7 +107,7 @@ class Lifepower(Battery):
 
         # Full battery capacity
         self.capacity = groups[3][0] / 100
-     
+
         # Temperature
         self.temp_sensors = 6
         self.temp1 = (groups[4][0] & 0xFF) - 50
@@ -118,7 +116,6 @@ class Lifepower(Battery):
         self.temp4 = (groups[4][3] & 0xFF) - 50
         self.temp5 = (groups[4][4] & 0xFF) - 50
         self.temp6 = (groups[4][5] & 0xFF) - 50
-
 
         # Alarms
         # 4th bit: Over Current Protection
@@ -151,7 +148,7 @@ class Lifepower(Battery):
             self.baud_rate,
             self.LENGTH_POS,
             self.LENGTH_CHECK,
-            self.LENGTH_FIXED
+            self.LENGTH_FIXED,
         )
         if data is False:
             logger.error(">>> ERROR: Incorrect Data")

--- a/etc/dbus-serialbattery/lifepower.py
+++ b/etc/dbus-serialbattery/lifepower.py
@@ -3,15 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from battery import Protection, Battery, Cell
 from utils import *
 from struct import *
+import re
 
 
 class Lifepower(Battery):
+
     def __init__(self, port, baud):
         super(Lifepower, self).__init__(port, baud)
         self.type = self.BATTERYTYPE
 
     command_general = b"\x7E\x01\x01\x00\xFE\x0D"
-    balancing = 0
+    command_hardware_version = b"\x7E\x01\x42\x00\xFC\x0D"
+    command_firmware_version =  b"\x7E\x01\x33\x00\xFE\x0D"
+    balancing = 0       
     BATTERYTYPE = "EG4 Lifepower"
     LENGTH_CHECK = 5
     LENGTH_POS = 3
@@ -27,10 +31,23 @@ class Lifepower(Battery):
         # After successful  connection get_settings will be call to set up the battery.
         # Set the current limits, populate cell count, etc
         # Return True if success, False for failure
-        self.max_battery_charge_current = MAX_BATTERY_CHARGE_CURRENT
+        self.max_battery_current = MAX_BATTERY_CURRENT
         self.max_battery_discharge_current = MAX_BATTERY_DISCHARGE_CURRENT
-        self.version = "EG4 BMS V1.0"
-        logger.info(self.hardware_version)
+        hardware_version = self.read_serial_data_eg4(self.command_hardware_version)
+        if hardware_version:
+            # I get some characters that I'm not able to figure out the encoding, probably chinese so I discard it
+            # Also remove any special character that is not printable or make no sense.
+            self.hardware_version = re.sub(r"[^a-zA-Z0-9-._ ]", '', str(hardware_version, encoding='utf-8', errors='ignore'))
+            logger.info("Hardware Version:" + self.hardware_version)
+
+        version = self.read_serial_data_eg4(self.command_firmware_version)
+        if version:
+            self.version = re.sub(r"[^a-zA-Z0-9-._ ]", '', str(version, encoding='utf-8', errors='ignore'))
+            logger.info("Firmware Version:" + self.version)
+        
+        # polling every second seems to create some error messages
+        # change to 2 seconds
+        self.poll_interval = 2000
         return True
 
     def refresh_data(self):
@@ -56,14 +73,8 @@ class Lifepower(Battery):
             # 01 02 0a 0b 0c 0d
             group_len = status_data[i + 1]
             end = i + 2 + (group_len * 2)
-            group_payload = status_data[i + 2 : end]
-            groups.append(
-                [
-                    unpack_from(">H", group_payload, i)[0]
-                    for i in range(0, len(group_payload), 2)
-                ]
-            )
-
+            group_payload = status_data[i + 2:end]
+            groups.append([unpack_from('>H', group_payload, i)[0] for i in range(0, len(group_payload), 2)])
             i = end
 
         # Cells
@@ -73,21 +84,29 @@ class Lifepower(Battery):
 
         self.cells = [Cell(True) for _ in range(0, self.cell_count)]
         for i, cell in enumerate(self.cells):
-            cell.voltage = groups[0][i] / 1000
+            # there is a situation where the MSB bit of the high byte may come set
+            # I got that when I got a high voltage alarm from the unit.
+            # make sure that bit is 0, by doing an AND with 32767 (01111111 1111111)
+            cell.voltage = (groups[0][i] & 32767) / 1000
 
         # Current
         self.current = (30000 - groups[1][0]) / 100
 
         # State of charge
         self.soc = groups[2][0] / 100
-
+     
         # Full battery capacity
         self.capacity = groups[3][0] / 100
-
+      
         # Temperature
-        # TODO There is a significant amount of temperature information being ignored here
-        # see https://github.com/slim-bean/powermon#group-5
-        self.temp1 = groups[4][0] - 50
+        self.temp_sensors = 6
+        self.temp1 = ( groups[4][0] & 0xFF) - 50
+        self.temp2 = ( groups[4][1] & 0xFF) - 50
+        self.temp3 = ( groups[4][2] & 0xFF) - 50
+        self.temp4 = ( groups[4][3] & 0xFF) - 50
+        self.temp5 = ( groups[4][4] & 0xFF) - 50
+        self.temp6 = ( groups[4][5] & 0xFF) - 50
+
 
         # Alarms
         # 4th bit: Over Current Protection
@@ -106,11 +125,6 @@ class Lifepower(Battery):
 
         # Voltage
         self.voltage = groups[7][0] / 100
-
-        # TODO State of health
-
-        self.hardware_version = "EG4 Lifepower " + str(self.cell_count) + " cells"
-
         return True
 
     def get_balancing(self):
@@ -119,14 +133,8 @@ class Lifepower(Battery):
     def read_serial_data_eg4(self, command):
         # use the read_serial_data() function to read the data and then do BMS
         # specific checks (crc, start bytes, etc)
-        data = read_serial_data(
-            command,
-            self.port,
-            self.baud_rate,
-            self.LENGTH_POS,
-            self.LENGTH_CHECK,
-            self.LENGTH_FIXED,
-        )
+        data = read_serial_data(command, self.port, self.baud_rate,
+                                self.LENGTH_POS, self.LENGTH_CHECK, self.LENGTH_FIXED)
         if data is False:
             logger.error(">>> ERROR: Incorrect Data")
             return False


### PR DESCRIPTION
This is a fix that corrects some issues with the original version of the EG4 LifePower support:
- cell voltage needs to be masked for a high bit that sometimes is set. I suspect it indicates an alarm to the cell, but it should be masked or the voltage shows a spike
- read hardware and firmware versions from the BMS itself. For my battery is produces firmware 3QT-YS00-16SV100A-V3.5 and the hardware version as "B".
- add more temperature reading sensors. I'm not sure if they are used.
I have been running it for at least 3 months with no issue, but I would welcome more testing.
![image](https://user-images.githubusercontent.com/24482951/210677600-1aec6a78-ea00-416f-a213-3fded5dc601f.png)

