### PR TITLE
publish correct allow_discharge flag to dbus

### DIFF
--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -365,7 +365,9 @@ class DbusHelper:
             1 if self.battery.charge_fet and self.battery.control_allow_charge else 0
         )
         self._dbusservice["/Io/AllowToDischarge"] = (
-            1 if self.battery.discharge_fet else 0
+            1
+            if self.battery.discharge_fet and self.battery.control_allow_discharge
+            else 0
         )
         self._dbusservice["/System/NrOfModulesBlockingCharge"] = (
             0


### PR DESCRIPTION
This PR will also publish to "Io/AllowToDischarge" = 0 if self.control_allow_discharge is unset. 
In my view, this was a bug before.