### PR TITLE
Show MOSFET temperature from JKBMS

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -76,6 +76,7 @@ class Battery(ABC):
         self.temp_sensors = None
         self.temp1 = None
         self.temp2 = None
+        self.temp_mos = None
         self.cells: List[Cell] = []
         self.control_charging = None
         self.control_voltage = None
@@ -140,6 +141,8 @@ class Battery(ABC):
             self.temp1 = min(max(value, -20), 100)
         if sensor == 2:
             self.temp2 = min(max(value, -20), 100)
+        if sensor == 'mos':
+            self.temp_mos = min(max(value, -20), 100
 
     def manage_charge_voltage(self) -> None:
         """
@@ -571,6 +574,12 @@ class Battery(ABC):
         return self.extract_from_temp_values(
             extractor=lambda temp1, temp2: max(temp1, temp2)
         )
+                   
+    def get_mos_temp(self) -> Union[float, None]:
+        if self.temp_mos is not None:
+            return self.temp_mos
+        else:
+            return None
 
     def log_cell_data(self) -> bool:
         if logger.getEffectiveLevel() > logging.INFO and len(self.cells) == 0:

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -224,6 +224,7 @@ class DbusHelper:
         # Create battery extras
         self._dbusservice.add_path("/System/MinCellTemperature", None, writeable=True)
         self._dbusservice.add_path("/System/MaxCellTemperature", None, writeable=True)
+        self._dbusservice.add_path("/System/MOSTemperature", None, writeable=True)
         self._dbusservice.add_path(
             "/System/MaxCellVoltage",
             None,
@@ -386,6 +387,7 @@ class DbusHelper:
         )
         self._dbusservice["/System/MinCellTemperature"] = self.battery.get_min_temp()
         self._dbusservice["/System/MaxCellTemperature"] = self.battery.get_max_temp()
+        self._dbusservice["/System/MOSTemperature"] = self.battery.get_mos_temp()
 
         # Charge control
         self._dbusservice[

--- a/etc/dbus-serialbattery/jkbms.py
+++ b/etc/dbus-serialbattery/jkbms.py
@@ -87,6 +87,11 @@ class Jkbms(Battery):
         temp2 = unpack_from(">H", self.get_data(status_data, b"\x82", offset, 2))[0]
         self.to_temp(1, temp1 if temp1 < 99 else (100 - temp1))
         self.to_temp(2, temp2 if temp2 < 99 else (100 - temp2))
+        
+        # MOSFET temperature
+        offset = cellbyte_count + 3
+        temp_mos = unpack_from(">H", self.get_data(status_data, b"\x80", offset, 2))[0]
+        self.to_temp('mos', temp_mos if temp_mos < 99 else (100 - temp_mos))
 
         offset = cellbyte_count + 12
         voltage = unpack_from(">H", self.get_data(status_data, b"\x83", offset, 2))[0]

--- a/etc/dbus-serialbattery/qml/PageBattery.qml
+++ b/etc/dbus-serialbattery/qml/PageBattery.qml
@@ -118,6 +118,15 @@ MbPage {
                 displayUnit: user.temperatureUnit
             }
         }
+        
+        MbItemValue {
+            description: qsTr("MOSFET temperature")
+            show: item.valid
+            item {
+                bind: service.path("/System/MOSTemperature")
+                displayUnit: user.temperatureUnit
+            }
+        }
 
         MbItemValue {
             description: qsTr("Air temperature")


### PR DESCRIPTION
I had a JKBMS repeatedly cutoff discharge for an unknown reason. After some digging, finally found it was the MOSFET temperature limits that were set too low. But I had to get close to the BMS and open the JKBMS app to use Bluetooth to get the MOSFET temp because it was not showing up through the serial battery driver. 

Took the time to did through the byte stream of data that JKBMS publishes and found that it sends the MOS temperature as well. 

Had to make changes in the battery class to accept a new temperature attribute, also create a dbus path and add a GUI interface to the qml file. 

It shouldn't break anything, but I couldn't test using a BMS that is not JK.