### PR TITLE
BLE JK BMS model recognition

### DIFF
--- a/buildfiles.lst
+++ b/buildfiles.lst
@@ -13,6 +13,7 @@ etc/dbus-serialbattery/installqml.sh
 etc/dbus-serialbattery/qml/PageBattery.qml
 etc/dbus-serialbattery/qml/PageBatteryCellVoltages.qml
 etc/dbus-serialbattery/qml/PageBatterySetup.qml
+etc/dbus-serialbattery/qml/PageLynxIonIo.qml
 etc/dbus-serialbattery/minimalmodbus.py
 etc/dbus-serialbattery/dbus-serialbattery.py
 etc/dbus-serialbattery/dbushelper.py

--- a/buildfiles.lst
+++ b/buildfiles.lst
@@ -13,7 +13,6 @@ etc/dbus-serialbattery/installqml.sh
 etc/dbus-serialbattery/qml/PageBattery.qml
 etc/dbus-serialbattery/qml/PageBatteryCellVoltages.qml
 etc/dbus-serialbattery/qml/PageBatterySetup.qml
-etc/dbus-serialbattery/qml/PageLynxIonIo.qml
 etc/dbus-serialbattery/minimalmodbus.py
 etc/dbus-serialbattery/dbus-serialbattery.py
 etc/dbus-serialbattery/dbushelper.py

--- a/etc/dbus-serialbattery/jkbms_ble.py
+++ b/etc/dbus-serialbattery/jkbms_ble.py
@@ -53,7 +53,7 @@ class Jkbms_Ble(Battery):
         if status is None:
             return False
 
-        if not status["device_info"]["vendor_id"].startswith("JK-"):
+        if not status["device_info"]["vendor_id"].startswith(("JK-", "JK_")):
             return False
 
         logger.info("JK BMS found!")


### PR DESCRIPTION
* Other JK BMS’ have an underscore in their vendor_id
* Don’t forget to include your new PageLynxIonIo in the buildlist

I have a couple of `JK_B1A8S20P` and am keen to get these supported with bluetooth to reduce the cabling/soldering etc.

The existing implementation translates cell voltages but not much else.
I hope this PR is just the beginning, are there some tips as to how I can decode the HCI responses into something I can pick through to match values?

Also, what's the preferred method to differentiate different models? Should we base that on vendor_id?

Really hoping I can help contribute to this brilliant project.