### PR TITLE
fix: remove duplicate log message when DeviceInstance setting has cha…

### DIFF
--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -93,10 +93,6 @@ class DbusHelper:
             self.battery.role, self.instance = self.get_role_instance()
             logger.info("Changed DeviceInstance = %d", self.instance)
             return
-        logger.info(
-            "Changed DeviceInstance = %d", float(self.settings["CellVoltageMin"])
-        )
-        # self._dbusservice['/History/ChargeCycles']
 
     def setup_vedbus(self):
         # Set up dbus service and device instance


### PR DESCRIPTION
…nged

It's also using float(self.settings["CellVoltageMin"] instead of self.instance