### PR TITLE
Add dynamic voltage adaption

### DIFF
--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -323,11 +323,12 @@ class DbusHelper:
                 if self.error_count >= 60:
                     loop.quit()
 
-            # This is to manage CCL\DCL
+            # This is to manage CCL/DCL
             self.battery.manage_charge_current()
 
-            # This is to manage CVCL
+            # This is to manage CVCL and DVCL
             self.battery.manage_charge_voltage()
+            self.battery.manage_discharge_voltage()
 
             # publish all the data from the battery object to dbus
             self.publish_dbus()
@@ -395,8 +396,8 @@ class DbusHelper:
             "/Info/MaxDischargeCurrent"
         ] = self.battery.control_discharge_current
 
-        # Voltage control
-        self._dbusservice["/Info/MaxChargeVoltage"] = self.battery.control_voltage
+        self._dbusservice["/Info/BatteryLowVoltage"] = self.battery.control_charge_voltage
+        self._dbusservice["/Info/MaxChargeVoltage"] = self.battery.control_discharge_voltage
 
         # Updates from cells
         self._dbusservice["/System/MinVoltageCellId"] = self.battery.get_min_cell_desc()

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -323,10 +323,10 @@ class DbusHelper:
                 if self.error_count >= 60:
                     loop.quit()
 
-            # This is to mannage CCL\DCL
+            # This is to manage CCL\DCL
             self.battery.manage_charge_current()
 
-            # This is to mannage CVCL
+            # This is to manage CVCL
             self.battery.manage_charge_voltage()
 
             # publish all the data from the battery object to dbus

--- a/etc/dbus-serialbattery/default_config.ini
+++ b/etc/dbus-serialbattery/default_config.ini
@@ -85,8 +85,15 @@ DC_CURRENT_LIMIT1_FRACTION = 0.1
 DC_CURRENT_LIMIT2_FRACTION = 0.3
 DC_CURRENT_LIMIT3_FRACTION = 0.5
 
-; Charge voltage control management enable (True/False).
+; Charge voltage control management enable (True/False/Dynamic).
 CVCM_ENABLE = False
+; Disharge voltage control management enable (True/False/Dynamic).
+DVCM_ENABLE = False
+
+; Range adjustment for dynamic voltage management.
+; Less is safer (but may charge/discharge slower). 0.5 … 1.
+CVCM_DYN_RANGE = 0.7
+DVCM_DYN_RANGE = 0.8
 
 ; Simulate Midpoint graph (True/False).
 MIDPOINT_ENABLE = False

--- a/etc/dbus-serialbattery/default_config.ini
+++ b/etc/dbus-serialbattery/default_config.ini
@@ -111,7 +111,7 @@ TIME_TO_SOC_POINTS =
 ; Specify TimeToSoc value type: [Valid values 1,2,3]
 ; TIME_TO_SOC_VALUE_TYPE = 1      ; Seconds
 ; TIME_TO_SOC_VALUE_TYPE = 2      ; Time string HH:MN:SC
-; Both Seconds and time str "<seconds> [days, HR:MN:SC]"
+; TIME_TO_SOC_VALUE_TYPE = 3      ; Both Seconds and time str "<seconds> [days, HR:MN:SC]"
 TIME_TO_SOC_VALUE_TYPE = 3
 ; Specify how many loop cycles between each TimeToSoc updates
 TIME_TO_SOC_LOOP_CYCLES = 5

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -172,8 +172,16 @@ DC_CURRENT_LIMIT3 = MAX_BATTERY_DISCHARGE_CURRENT * float(
     config["DEFAULT"]["DC_CURRENT_LIMIT3_FRACTION"]
 )
 
-# Charge voltage control management enable (True/False).
+# Charge voltage control management enable (True/False/Dynamic).
+CVCM_DYNAMIC = "Dynamic" == config["DEFAULT"]["CVCM_ENABLE"]
 CVCM_ENABLE = "True" == config["DEFAULT"]["CVCM_ENABLE"]
+# Discharge voltage control management enable (True/False/Dynamic).
+DVCM_DYNAMIC = "Dynamic" == config["DEFAULT"]["DVCM_ENABLE"]
+DVCM_ENABLE = "True" == config["DEFAULT"]["DVCM_ENABLE"]
+
+# dynamic voltage control: range factor. Should be 0.5…1 or so.
+CVCM_DYN_RANGE = float(config["DEFAULT"]["CVCM_DYN_RANGE"])
+DVCM_DYN_RANGE = float(config["DEFAULT"]["DVCM_DYN_RANGE"])
 
 # Simulate Midpoint graph (True/False).
 MIDPOINT_ENABLE = "True" == config["DEFAULT"]["MIDPOINT_ENABLE"]


### PR DESCRIPTION
This PR adds a simple but very effective way to adapt a battery's voltage limits, based on the states of its individual cells.

To explain the algorithm, let's assume the configured maximum cell voltage is 3.5V. If the top cell is at 3.4V and all others are at 3.39 or so, the pack is well-balanced and we can (most likely) safely charge until they're all at or slightly below 3.5V. The maximum is thus `3.5V*n_cells`.

However, if these other cells are at 3.3V or so, we can only increase the total pack voltage by 0.1V before the top cell's voltage exceeds 3.5V. In this case the other cell voltages will not move much, if at all, due to the highly nonlinear charge curve of LiFePo4 cells. The maximum voltage the system can use is now `3.3V*(n_cells-1) + 3.5V`, or `3.3V*n_cells + 0.2V`, which is significantly less.

This code uses the voltage difference between the top cell and the configured maximum to determine how much to "discount" the *other* cells' contribution to the (additional) voltage which the battery can reach before the top cell goes over the limit.

This method is not perfect, but in combination with the existing current limitation it reliably prevents over-voltage cells even when the battery has never been balanced.

The same argument in reverse applies to the minimum battery voltage.
