### PR TITLE
fix dbus-daemon memory leak

### DIFF
--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -57,11 +57,7 @@ logger.info("Starting dbus-serialbattery")
 
 def main():
     def poll_battery(loop):
-        # Run in separate thread. Pass in the mainloop so the thread can kill us if there is an exception.
-        poller = Thread(target=lambda: helper.publish_battery(loop))
-        # Thread will die with us if deamon
-        poller.daemon = True
-        poller.start()
+        helper.publish_battery(loop)
         return True
 
     def get_battery(_port) -> Union[Battery, None]:


### PR DESCRIPTION
`poll_battery` is already called from the dbus mainloop in a separate thread. Opening a new thread here (and especially never closing it) will accumulate threads and leads to problems like `dbus-daemon` memory usage increasing over time, leading to eventual reboot

disclaimer: I have not tested this with a USB/serial connection, only Bluetooth