### PR TITLE
Jkbms ble

### DIFF
--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -48,6 +48,7 @@ class Daly(Battery):
             ser = open_serial_port(self.port, self.baud_rate)
             if ser is not None:
                 result = self.read_status_data(ser)
+                self.read_soc_data(ser)
                 ser.close()
 
         except Exception as err:

--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -114,10 +114,11 @@ class Daly(Battery):
         crntMaxValid = utils.MAX_BATTERY_CHARGE_CURRENT * 1.3
         triesValid = 2
         while triesValid > 0:
+            triesValid -= 1
             soc_data = self.read_serial_data_daly(ser, self.command_soc)
             # check if connection success
             if soc_data is False:
-                return False
+                continue
 
             voltage, tmp, current, soc = unpack_from(">hhhh", soc_data)
             current = (
@@ -132,8 +133,6 @@ class Daly(Battery):
                 return True
 
             logger.warning("read_soc_data - triesValid " + str(triesValid))
-            triesValid -= 1
-
         return False
 
     def read_alarm_data(self, ser):

--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -308,6 +308,7 @@ class Daly(Battery):
                         )
                     bufIdx += 13  # BBBBBhhhBB -> 13 byte
                 else:
+                    bufIdx += 1   # step through buffer to find valid start
                     logger.warning("bad cell voltages header")
         return True
 

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -392,7 +392,7 @@ def open_serial_port(port, baud):
     return ser
 
 
-# Read data from previously openned serial port
+# Read data from previously opened serial port
 def read_serialport_data(
     ser: serial.Serial,
     command,
@@ -441,14 +441,8 @@ def read_serialport_data(
 
         count = 0
         data = bytearray(res)
-
-        packetlen = (
-            length_fixed
-            if length_fixed is not None
-            else length_pos + length_byte_size + length + length_check
-        )
-        while len(data) < packetlen:
-            res = ser.read(packetlen - len(data))
+        while len(data) <= length + length_check:
+            res = ser.read(length + length_check)
             data.extend(res)
             # logger.info('serial data length ' + str(len(data)))
             sleep(0.005)


### PR DESCRIPTION
- read_serialport_data() copied to daly.py and original state in utils.py restored. Other BMS should work again now
- improvements in daly.py:
  - further improvement of serial parser
  - further improvement of cell data parser
  - read_soc() also retries the serial transmission if failed
  - add cell balance state info. before, cells were always red, now the color represents the balance state correctly
  - fix connection log startup message. now correctly displays voltage/current/soc