### PR TITLE
changed jkbms_ble to dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -119,6 +119,7 @@ body:
         - Please select
         - Serial USB adapter to TTL
         - Serial USB adapter to RS485
+        - Raspberry Pi RS485 HAT
         - Bluetooth
     validations:
       required: true

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -23,9 +23,9 @@ jobs:
           VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v//')
           echo $VERSION
           echo
-          head -n 37 etc/dbus-serialbattery/utils.py | tail -n 3
+          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 3
           sed -i --regexp-extended --expression="s/[0-9]+\.[0-9]+\.[0-9a-z\_\-]+/$VERSION/" "etc/dbus-serialbattery/utils.py"
-          head -n 37 etc/dbus-serialbattery/utils.py | tail -n 3
+          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 3
 
       - name: build release archive
         run: |

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -17,6 +17,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Replace version string
+        run: |
+          echo $GITHUB_REF_NAME
+          VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v//')
+          echo $VERSION
+          echo
+          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 1
+          sed -i --regexp-extended --expression='s/[0-9]+\.[0-9]+\.[0-9a-z\_\-]+/$VERSION/' "etc/dbus-serialbattery/utils.py"
+          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 1
+
       - name: build release archive
         run: |
           find . -type f -name "*.py" -exec chmod +x {} \;

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -23,9 +23,9 @@ jobs:
           VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v//')
           echo $VERSION
           echo
-          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 1
-          sed -i --regexp-extended --expression='s/[0-9]+\.[0-9]+\.[0-9a-z\_\-]+/$VERSION/' "etc/dbus-serialbattery/utils.py"
-          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 1
+          head -n 37 etc/dbus-serialbattery/utils.py | tail -n 3
+          sed -i --regexp-extended --expression="s/[0-9]+\.[0-9]+\.[0-9a-z\_\-]+/$VERSION/" "etc/dbus-serialbattery/utils.py"
+          head -n 37 etc/dbus-serialbattery/utils.py | tail -n 3
 
       - name: build release archive
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Replace version string
+        run: |
+          echo $GITHUB_REF_NAME
+          VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v//')
+          echo $VERSION
+          echo
+          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 3
+          sed -i --regexp-extended --expression="s/[0-9]+\.[0-9]+\.[0-9a-z\_\-]+/$VERSION/" "etc/dbus-serialbattery/utils.py"
+          head -n 39 etc/dbus-serialbattery/utils.py | tail -n 3
+
       - name: build release archive
         run: |
           find . -type f -name "*.py" -exec chmod +x {} \;

--- a/etc/dbus-serialbattery/install.sh
+++ b/etc/dbus-serialbattery/install.sh
@@ -6,10 +6,15 @@
 echo ""
 PS3="Select which version you want to install and enter the corresponding number [1]: "
 
-select version in "latest release (recommended)" "nightly build" "local tar file" "specific version" "quit"
+select version in "latest release (recommended)" "specific version" "nightly build" "local tar file" "quit"
 do
     case $version in
         "latest release (recommended)")
+            echo "Selected: $version"
+            #echo "Selected number: $REPLY"
+            break
+            ;;
+        "specific version")
             echo "Selected: $version"
             #echo "Selected number: $REPLY"
             break
@@ -20,11 +25,6 @@ do
             break
             ;;
         "local tar file")
-            echo "Selected: $version"
-            #echo "Selected number: $REPLY"
-            break
-            ;;
-        "specific version")
             echo "Selected: $version"
             #echo "Selected number: $REPLY"
             break
@@ -46,11 +46,6 @@ if [ "$version" = "latest release (recommended)" ]; then
     curl -s https://api.github.com/repos/Louisvdw/dbus-serialbattery/releases/latest | grep "browser_download_url.*gz" | cut -d : -f 2,3 | tr -d \" | wget -O /tmp/venus-data.tar.gz -qi -
 fi
 
-## local tar file
-if [ "$version" = "local tar file" ]; then
-    echo "Make sure the file is available at \"/var/volatile/tmp/venus-data.tar.gz\""
-fi
-
 ## specific version
 if [ "$version" = "specific version" ]; then
     # read the url
@@ -62,7 +57,10 @@ if [ "$version" = "specific version" ]; then
     fi
 fi
 
-
+## local tar file
+if [ "$version" = "local tar file" ]; then
+    echo "Make sure the file is available at \"/var/volatile/tmp/venus-data.tar.gz\""
+fi
 
 # backup config.ini
 if [ -f "/data/etc/dbus-serialbattery/config.ini" ]; then
@@ -72,7 +70,7 @@ fi
 
 
 ## extract the tar file
-if [ "$version" = "latest release (recommended)" ] || [ "$version" = "local tar file" ] || [ "$version" = "specific version" ]; then
+if [ "$version" = "latest release (recommended)" ] || [ "$version" = "specific version" ] || [ "$version" = "local tar file" ]; then
 
     # extract driver
     if [ -f "/tmp/venus-data.tar.gz" ]; then

--- a/etc/dbus-serialbattery/install.sh
+++ b/etc/dbus-serialbattery/install.sh
@@ -96,7 +96,7 @@ if [ "$version" = "nightly build" ]; then
 
     PS3="Select the branch from wich you want to install the current code (possible bugs included): "
 
-    select branch in master jkbms_ble quit
+    select branch in master dev quit
     do
         case $branch in
             master)
@@ -104,7 +104,7 @@ if [ "$version" = "nightly build" ]; then
                 #echo "Selected number: $REPLY"
                 break
                 ;;
-            jkbms_ble)
+            dev)
                 echo "Selected branch: $branch"
                 #echo "Selected number: $REPLY"
                 break


### PR DESCRIPTION
* Added: Driver version in `utils.py` is automatically replaced with the version specified in the git `tag`. This makes sure, that the version also corresponds to the tag version.

Example:
```bash
# in the branch
DRIVER_VERSION = "1.0.20230508dev"

# in the tar file
DRIVER_VERSION = "1.0.20230509beta"
```