### PR TITLE
Limit control voltage to max charge voltage

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -241,14 +241,18 @@ class Battery(ABC):
                 ):
                     self.linear_cvl_last_set = int(time())
 
-                    # Keep penalty above min battery voltage
+                    # Keep penalty above min battery voltage and below max battery voltage
                     self.control_voltage = round(
-                        max(
-                            voltageSum - penaltySum,
-                            utils.MIN_CELL_VOLTAGE * self.cell_count,
+                        min(
+                            max(
+                                voltageSum - penaltySum,
+                                utils.MIN_CELL_VOLTAGE * self.cell_count,
+                            ),
+                            utils.MAX_CELL_VOLTAGE * self.cell_count
                         ),
                         3,
                     )
+
 
                 self.charge_mode = (
                     "Bulk dynamic"


### PR DESCRIPTION
in my setup cell voltage still default
i have seen , that control_voltage get sometimes  values above 55.2
![Screenshot 2023-05-20 at 19 42 24](https://github.com/Louisvdw/dbus-serialbattery/assets/50322596/448d1132-0483-4ca1-b6ad-dbdd00585426)
![Screenshot 2023-05-20 at 19 43 38](https://github.com/Louisvdw/dbus-serialbattery/assets/50322596/e2392f5d-2622-4e90-b840-108d3666df83)

.... not sure but it could occurs here. Could you take a look at this change.
thank you.

; --------- Cell Voltages ---------
; Description: Cell min/max voltages which are used to calculate the min/max battery voltage
; Example: 16 cells * 3.45V/cell = 55.2V max charge voltage. 16 cells * 2.90V = 46.4V min discharge voltage
MIN_CELL_VOLTAGE   = 2.900
; Max voltage can seen as absorption voltage
MAX_CELL_VOLTAGE   = 3.450
FLOAT_CELL_VOLTAGE = 3.382
TIME_TO_GO_ENABLE = False