### PR TITLE
bugfix: LLTJBD BMS ignore non ASCII letters for hardware version

### DIFF
--- a/etc/dbus-serialbattery/bms/lltjbd.py
+++ b/etc/dbus-serialbattery/bms/lltjbd.py
@@ -445,7 +445,7 @@ class LltJbd(Battery):
 
         self._product_name = unpack_from(
             ">" + str(len(hardware_data)) + "s", hardware_data
-        )[0].decode()
+        )[0].decode("ascii", errors="ignore")
         logger.debug(self._product_name)
         return True
 


### PR DESCRIPTION
#636 primary issue fixed for decoding hardware revision and ignore invalid characters