### PR TITLE
implement callback function for update

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Union, Tuple, List
+from typing import Union, Tuple, List, Callable
 
 from utils import logger
 import utils
@@ -147,6 +147,17 @@ class Battery(ABC):
         MAX_BATTERY_CHARGE_CURRENT, MAX_BATTERY_DISCHARGE_CURRENT, cell_count, capacity
 
         :return: false when fail, true if successful
+        """
+        return False
+
+    def use_callback(self, callback: Callable) -> bool:
+        """
+        Each driver may override this function to indicate whether it is
+        able to provide value updates on its own.
+
+        :return: false when battery cannot provide updates by itself and will be polled
+                 every poll_interval milliseconds for new values
+                 true if callable should be used for updates as they arrive from the battery
         """
         return False
 

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from battery import Battery, Cell
+from typing import Callable
 from utils import logger
 from bms.jkbms_brn import Jkbms_Brn
 from bleak import BleakScanner, BleakError
@@ -140,6 +141,10 @@ class Jkbms_Ble(Battery):
         )
         logger.info("BAT: " + self.hardware_version)
         return True
+
+    def use_callback(self, callback: Callable) -> bool:
+        self.jk.set_callback(callback)
+        return callback is not None
 
     def refresh_data(self):
         # call all functions that will refresh the battery data.

--- a/etc/dbus-serialbattery/bms/jkbms_brn.py
+++ b/etc/dbus-serialbattery/bms/jkbms_brn.py
@@ -91,6 +91,8 @@ class Jkbms_Brn:
     waiting_for_response = ""
     last_cell_info = 0
 
+    _new_data_callback = None
+
     def __init__(self, addr):
         self.address = addr
         self.bt_thread = threading.Thread(target=self.connect_and_scrape)
@@ -240,6 +242,9 @@ class Jkbms_Brn:
             if self.waiting_for_response == "device_info":
                 self.waiting_for_response = ""
 
+    def set_callback(self, callback):
+        self._new_data_callback = callback
+
     def assemble_frame(self, data: bytearray):
         if len(self.frame_buffer) > MAX_RESPONSE_SIZE:
             info("data dropped because it alone was longer than max frame length")
@@ -261,6 +266,8 @@ class Jkbms_Brn:
                 debug("great success! frame complete and sane, lets decode")
                 self.decode()
                 self.frame_buffer = []
+                if self._new_data_callback is not None:
+                    self._new_data_callback()
 
     def ncallback(self, sender: int, data: bytearray):
         debug(f"------> NEW PACKAGE!laenge:  {len(data)}")

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -152,7 +152,8 @@ def main():
         sys.exit(1)
 
     # Poll the battery at INTERVAL and run the main loop
-    gobject.timeout_add(battery.poll_interval, lambda: poll_battery(mainloop))
+    if not battery.use_callback(lambda: poll_battery(mainloop)):
+        gobject.timeout_add(battery.poll_interval, lambda: poll_battery(mainloop))
     try:
         mainloop.run()
     except KeyboardInterrupt:

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -151,9 +151,12 @@ def main():
         logger.error("ERROR >>> Problem with battery set up at " + port)
         sys.exit(1)
 
-    # Poll the battery at INTERVAL and run the main loop
+    # try using active callback on this battery
     if not battery.use_callback(lambda: poll_battery(mainloop)):
+        # if not possible, poll the battery every poll_interval milliseconds
         gobject.timeout_add(battery.poll_interval, lambda: poll_battery(mainloop))
+
+    # Run the main loop
     try:
         mainloop.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
JKBMS over Bluetooth sends updates by itself, so we don't need to poll it. This patch makes it publish new values to dbus as soon as they arrive via Bluetooth.