### PR TITLE
Exclude devices from driver startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v1.0.0
+## v1.0.x
+* Added: Exclude a device from beeing used by the dbus-serialbattery driver by @mr-manuel
+* Added: Implement callback function for update by @seidler2547
+
+## v1.0.20230531
 
 ### ATTENTION: Breaking changes! The config is now done in the `config.ini`. All values from the `utils.py` gets lost. The changes in the `config.ini` will persists future updates.
 

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -191,6 +191,10 @@ TIME_TO_SOC_INC_FROM = False
 ; Ant, MNB, Sinowealth
 BMS_TYPE =
 
+; Exclute this serial devices from the driver startup
+; Example: /dev/ttyUSB2, /dev/ttyUSB4
+EXCLUDED_DEVICES =
+
 ; Publish the config settings to the dbus path "/Info/Config/"
 PUBLISH_CONFIG_VALUES = 1
 

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -100,7 +100,17 @@ def main():
     def get_port() -> str:
         # Get the port we need to use from the argument
         if len(sys.argv) > 1:
-            return sys.argv[1]
+            port = sys.argv[1]
+            if port not in utils.EXCLUDED_DEVICES:
+                return port
+            else:
+                logger.info(
+                    "Stopping dbus-serialbattery: "
+                    + str(port)
+                    + " is excluded trough the config file"
+                )
+                sleep(86400)
+                sys.exit(0)
         else:
             # just for MNB-SPI
             logger.info("No Port needed")

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -27,7 +27,10 @@ def _get_list_from_config(
 ) -> List[Any]:
     rawList = config[group][option].split(",")
     return list(
-        map(mapper, [item for item in rawList if item != "" and item is not None])
+        map(
+            mapper,
+            [item.strip() for item in rawList if item != "" and item is not None],
+        )
     )
 
 
@@ -35,7 +38,7 @@ def _get_list_from_config(
 # if not specified: baud = 9600
 
 # Constants - Need to dynamically get them in future
-DRIVER_VERSION = "1.0.20230531"
+DRIVER_VERSION = "1.0.20230526dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 
@@ -271,6 +274,10 @@ TIME_TO_SOC_INC_FROM = "True" == config["DEFAULT"]["TIME_TO_SOC_INC_FROM"]
 # https://louisvdw.github.io/dbus-serialbattery/general/install#how-to-enable-a-disabled-bms
 # Ant, MNB, Sinowealth
 BMS_TYPE = config["DEFAULT"]["BMS_TYPE"]
+
+EXCLUDED_DEVICES = _get_list_from_config(
+    "DEFAULT", "EXCLUDED_DEVICES", lambda v: str(v)
+)
 
 # Publish the config settings to the dbus path "/Info/Config/"
 PUBLISH_CONFIG_VALUES = int(config["DEFAULT"]["PUBLISH_CONFIG_VALUES"])


### PR DESCRIPTION
This prevents blocking the serial port