### PR TITLE
de-deprecate revov

### DIFF
--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -27,7 +27,7 @@ from bms.ecs import Ecs
 from bms.heltecmodbus import HeltecModbus
 from bms.hlpdatabms4s import HLPdataBMS4S
 from bms.jkbms import Jkbms
-from bms.lifepower import Lifepower
+# from bms.lifepower import Lifepower #Deprecate out non working version
 from bms.lltjbd import LltJbd
 from bms.renogy import Renogy
 from bms.seplos import Seplos
@@ -35,6 +35,7 @@ from bms.seplos import Seplos
 # from bms.ant import Ant
 # from bms.mnb import MNB
 # from bms.sinowealth import Sinowealth
+from bms.revov import Revov  # Undeprecate working version
 
 supported_bms_types = [
     {"bms": Daly, "baud": 9600, "address": b"\x40"},
@@ -43,11 +44,12 @@ supported_bms_types = [
     {"bms": HeltecModbus, "baud": 9600},
     {"bms": HLPdataBMS4S, "baud": 9600},
     {"bms": Jkbms, "baud": 115200},
-    {"bms": Lifepower, "baud": 9600},
+    # {"bms": Lifepower, "baud": 9600},
     {"bms": LltJbd, "baud": 9600},
     {"bms": Renogy, "baud": 9600, "address": b"\x30"},
     {"bms": Renogy, "baud": 9600, "address": b"\xF7"},
     {"bms": Seplos, "baud": 19200},
+    {"bms": Revov, "baud": 9600},
     # {"bms": Ant, "baud": 19200},
     # {"bms": MNB, "baud": 9600},
     # {"bms": Sinowealth},


### PR DESCRIPTION
revov.py code update 
Added debug function for logging, and some code cleanup.



lifepower bms code driver doesn't appear to work on my own TianPower bms - different modbus call, and temp sensor differs, so it breaks.

Pushed code works ;  I'll let you decide how to get both running?  Maybe comment out one or the other type instructions..?


Log example:

@40000000647df0332acf05c4 WARNING:SerialBattery:== Modbus packet good ==
@40000000647df0332ade923c WARNING:SerialBattery:I34 J0 G16 B2
@40000000647df0332ae89c8c WARNING:SerialBattery:I38 J1 G1 B2
@40000000647df0332af4160c WARNING:SerialBattery:I42 J2 G1 B2
@40000000647df0332b0081bc WARNING:SerialBattery:I46 J3 G1 B2
@40000000647df0332b09e7fc WARNING:SerialBattery:I54 J4 G3 B2
@40000000647df0332b13c754 WARNING:SerialBattery:I66 J5 G5 B2
@40000000647df0332b1cd7a4 WARNING:SerialBattery:I70 J6 G1 B2
@40000000647df0332b2714bc WARNING:SerialBattery:I74 J7 G1 B2
@40000000647df0332b2e2554 WARNING:SerialBattery:I78 J8 G1 B2
@40000000647df0332b38b474 WARNING:SerialBattery:I82 J9 G1 B2
@40000000647df0332b44ddbc WARNING:SerialBattery:I88 J10 G1 B4
@40000000647df0332b4f68f4 WARNING:SerialBattery:I94 J11 G1 B4
@40000000647df0332b580414 WARNING:SerialBattery:I100 J12 G1 B4
@40000000647df0332b60c644 WARNING:SerialBattery:I106 J13 G1 B4
@40000000647df0332b6cf374 WARNING:SerialBattery:I112 J14 G1 B4
@40000000647df0332b7b8204 INFO:SerialBattery:Cell Count: 16
@40000000647df0332b89418c INFO:SerialBattery:Cell 0: 3.36
@40000000647df0332b92bf3c INFO:SerialBattery:Cell 1: 3.355
@40000000647df0332b9ae914 INFO:SerialBattery:Cell 2: 3.368
@40000000647df0332ba22c74 INFO:SerialBattery:Cell 3: 3.372
@40000000647df0332ba9c5c4 INFO:SerialBattery:Cell 4: 3.379
@40000000647df0332bb0f1b4 INFO:SerialBattery:Cell 5: 3.391
@40000000647df0332bbba3fc INFO:SerialBattery:Cell 6: 3.552
@40000000647df0332bc41fdc INFO:SerialBattery:Cell 7: 3.565
@40000000647df0332bcbf7ac INFO:SerialBattery:Cell 8: 3.374
@40000000647df0332bd49e84 INFO:SerialBattery:Cell 9: 3.345
@40000000647df0332bdc3fa4 INFO:SerialBattery:Cell 10: 3.405
@40000000647df0332be57ed4 INFO:SerialBattery:Cell 11: 3.427
@40000000647df0332bee50a4 INFO:SerialBattery:Cell 12: 3.343
@40000000647df0332bf647b4 INFO:SerialBattery:Cell 13: 3.375
@40000000647df0332bfbd594 INFO:SerialBattery:Cell 14: 3.368
@40000000647df0332c036afc INFO:SerialBattery:Cell 15: 3.367
@40000000647df0332c0ad56c INFO:SerialBattery:Current: 0.0
@40000000647df0332c110374 INFO:SerialBattery:SoC: 100.0
@40000000647df0332c176444 INFO:SerialBattery:Capacity: 180.0
@40000000647df0332c1e1334 INFO:SerialBattery:Protection
@40000000647df0332c260274 INFO:SerialBattery:Cycles: 201
@40000000647df0332c2cc8d4 INFO:SerialBattery:Voltage: 54.34
@40000000647df0352a5d2184 WARNING:SerialBattery:Modbus Address: 124
@40000000647df0352aba415c WARNING:SerialBattery:Modbus Type   : 1
@40000000647df0352aba58cc WARNING:SerialBattery:Modbus Command: 1
@40000000647df0352aba6484 WARNING:SerialBattery:Modbus PackLen: 118
@40000000647df0352abb2004 WARNING:SerialBattery:Modbus Packet : [7C:01:01:76:01:10:0D:20:0D:1B:0D:28:8D:2C:0D:33:8D:3F:0D:E0:CD:ED:0D:2E:0D:11:0D:4D:8D:62:0D:0F:8D:2E:0D:28:8D:27:02:01:75:30:03:01:27:10:04:01:46:50:05:03:00:42:00:42:20:44:06:05:00:00:10:10:00:00:00:00:00:01:07:01:00:C9:08:01:15:3A:09:01:27:10:0A:01:00:01:0B:01:00:00:E2:F7:0C:01:00:00:3D:D0:0D:01:00:40:00:00:0E:01:00:40:00:00:0F:01:00:24:EE:9A:10:01:00:09:C6:B9:1C:0D]
