### PR TITLE
Improve Battery Voltage Handling in Linear Absorption Mode

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -245,8 +245,6 @@ class Battery(ABC):
         penaltySum = 0
         tDiff = 0
 
-        PENALTY_BUFFER = 0.002
-
         try:
             if utils.CVCM_ENABLE:
                 # calculate battery sum
@@ -259,9 +257,7 @@ class Battery(ABC):
                         if voltage > utils.MAX_CELL_VOLTAGE:
                             # foundHighCellVoltage: reset to False is not needed, since it is recalculated every second
                             foundHighCellVoltage = True
-                            penaltySum += (
-                                voltage - utils.MAX_CELL_VOLTAGE + PENALTY_BUFFER
-                            )
+                            penaltySum += voltage - utils.MAX_CELL_VOLTAGE
 
                 voltageDiff = self.get_max_cell_voltage() - self.get_min_cell_voltage()
 

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -241,7 +241,7 @@ class Battery(ABC):
                         <= utils.CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL
                         and self.allow_max_voltage
                     ):
-                        self.max_voltage_start_time = time()
+                        self.max_voltage_start_time = int(time())
 
                     # allow max voltage again, if cells are unbalanced or SoC threshold is reached
                     elif (
@@ -250,7 +250,7 @@ class Battery(ABC):
                     ) and not self.allow_max_voltage:
                         self.allow_max_voltage = True
                 else:
-                    tDiff = time() - self.max_voltage_start_time
+                    tDiff = int(time()) - self.max_voltage_start_time
                     # if utils.MAX_VOLTAGE_TIME_SEC < tDiff:
                     # keep max voltage for 300 more seconds
                     if 300 < tDiff:

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -215,6 +215,8 @@ class Battery(ABC):
         voltageSum = 0
         penaltySum = 0
         tDiff = 0
+        
+        PENALTY_BUFFER = 0.010
 
         try:
             if utils.CVCM_ENABLE:
@@ -228,7 +230,7 @@ class Battery(ABC):
                         if voltage > utils.MAX_CELL_VOLTAGE:
                             # foundHighCellVoltage: reset to False is not needed, since it is recalculated every second
                             foundHighCellVoltage = True
-                            penaltySum += voltage - utils.MAX_CELL_VOLTAGE - 0.010
+                            penaltySum += voltage - utils.MAX_CELL_VOLTAGE + PENALTY_BUFFER
 
                 voltageDiff = self.get_max_cell_voltage() - self.get_min_cell_voltage()
 

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -205,7 +205,7 @@ class Battery(ABC):
                 self.manage_charge_voltage_step()
         # on CVCM_ENABLE = False apply max voltage
         else:
-            self.control_voltage = round((self.max_battery_voltage), 3)
+            self.control_voltage = round(self.max_battery_voltage, 3)
             self.charge_mode = "Keep always max voltage"
 
     def manage_charge_voltage_linear(self) -> None:
@@ -304,9 +304,7 @@ class Battery(ABC):
                 )
 
             elif self.allow_max_voltage:
-                self.control_voltage = round(
-                    (self.max_battery_voltage), 3
-                )
+                self.control_voltage = round(self.max_battery_voltage, 3)
                 self.charge_mode = (
                     "Bulk" if self.max_voltage_start_time is None else "Absorption"
                 )

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -68,8 +68,6 @@ class Battery(ABC):
         self.max_battery_charge_current = None
         self.max_battery_discharge_current = None
         self.has_settings = 0
-        self.max_battery_voltage = None
-        self.min_battery_voltage = None
 
         self.init_values()
 
@@ -104,14 +102,16 @@ class Battery(ABC):
         self.cells: List[Cell] = []
         self.control_charging = None
         self.control_voltage = None
+        self.max_battery_voltage = utils.MAX_CELL_VOLTAGE * self.cell_count
+        self.min_battery_voltage = utils.MIN_CELL_VOLTAGE * self.cell_count
         self.allow_max_voltage = True
+        self.max_voltage_start_time = None
         self.charge_mode = None
         self.charge_limitation = None
         self.discharge_limitation = None
         self.linear_cvl_last_set = 0
         self.linear_ccl_last_set = 0
         self.linear_dcl_last_set = 0
-        self.max_voltage_start_time = None
         self.control_current = None
         self.control_previous_total = None
         self.control_previous_max = None
@@ -198,8 +198,6 @@ class Battery(ABC):
         manages the charge voltage by setting self.control_voltage
         :return: None
         """
-        self.max_battery_voltage = utils.MAX_CELL_VOLTAGE * self.cell_count
-        self.min_battery_voltage = utils.MIN_CELL_VOLTAGE * self.cell_count
         if utils.CVCM_ENABLE:
             if utils.LINEAR_LIMITATION_ENABLE:
                 self.manage_charge_voltage_linear()

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -290,6 +290,8 @@ class Battery(ABC):
                     else "Absorption dynamic"
                     # + "(vS: "
                     # + str(round(voltageSum, 2))
+                    # + " - tDiff: "
+                    # + str(tDiff)
                     # + " - pS: "
                     # + str(round(penaltySum, 2))
                     # + ")"

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -198,6 +198,8 @@ class Battery(ABC):
         manages the charge voltage by setting self.control_voltage
         :return: None
         """
+        self.max_battery_voltage = utils.MAX_CELL_VOLTAGE * self.cell_count
+        self.min_battery_voltage = utils.MIN_CELL_VOLTAGE * self.cell_count
         if utils.CVCM_ENABLE:
             if utils.LINEAR_LIMITATION_ENABLE:
                 self.manage_charge_voltage_linear()

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -220,7 +220,7 @@ class Battery(ABC):
         penaltySum = 0
         tDiff = 0
 
-        PENALTY_BUFFER = 0.010
+        PENALTY_BUFFER = 0.002
 
         try:
             if utils.CVCM_ENABLE:

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -70,7 +70,7 @@ class Battery(ABC):
         self.has_settings = 0
         self.max_battery_voltage = None
         self.min_battery_voltage = None
-        
+
         self.init_values()
 
         # used to identify a BMS when multiple BMS are connected - planned for future use
@@ -217,9 +217,9 @@ class Battery(ABC):
         voltageSum = 0
         penaltySum = 0
         tDiff = 0
-        
+
         PENALTY_BUFFER = 0.010
-        
+
         try:
             if utils.CVCM_ENABLE:
                 # calculate battery sum
@@ -232,15 +232,16 @@ class Battery(ABC):
                         if voltage > utils.MAX_CELL_VOLTAGE:
                             # foundHighCellVoltage: reset to False is not needed, since it is recalculated every second
                             foundHighCellVoltage = True
-                            penaltySum += voltage - utils.MAX_CELL_VOLTAGE + PENALTY_BUFFER
+                            penaltySum += (
+                                voltage - utils.MAX_CELL_VOLTAGE + PENALTY_BUFFER
+                            )
 
                 voltageDiff = self.get_max_cell_voltage() - self.get_min_cell_voltage()
 
                 if self.max_voltage_start_time is None:
                     # start timer, if max voltage is reached and cells are balanced
                     if (
-                        self.max_battery_voltage - utils.VOLTAGE_DROP
-                        <= voltageSum
+                        self.max_battery_voltage - utils.VOLTAGE_DROP <= voltageSum
                         and voltageDiff
                         <= utils.CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL
                         and self.allow_max_voltage
@@ -306,7 +307,10 @@ class Battery(ABC):
             elif self.allow_max_voltage:
                 self.control_voltage = round(self.max_battery_voltage, 3)
                 self.charge_mode = (
-                    "Bulk" if self.max_voltage_start_time is None else "Absorption"
+                    # "Bulk" if self.max_voltage_start_time is None else "Absorption"
+                    "Bulk"
+                    if self.max_voltage_start_time is None
+                    else "Absorption" + "(tDiff: " + str(tDiff) + ")"
                 )
 
             else:
@@ -346,7 +350,10 @@ class Battery(ABC):
 
                 if self.max_voltage_start_time is None:
                     # check if max voltage is reached and start timer to keep max voltage
-                    if self.max_battery_voltage - utils.VOLTAGE_DROP <= voltageSum and self.allow_max_voltage:
+                    if (
+                        self.max_battery_voltage - utils.VOLTAGE_DROP <= voltageSum
+                        and self.allow_max_voltage
+                    ):
                         # example 2
                         self.max_voltage_start_time = time()
 

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -284,6 +284,8 @@ class Battery(ABC):
                     if 300 < tDiff:
                         self.allow_max_voltage = False
                         self.max_voltage_start_time = None
+                    # we don't forget to reset max_voltage_start_time wenn we going to bulk(dynamic) mode
+                    # regardless of whether we were in absorption mode or not
                     if voltageSum < self.max_battery_voltage - utils.VOLTAGE_DROP:
                         self.max_voltage_start_time = None
 
@@ -333,7 +335,7 @@ class Battery(ABC):
                     # "Bulk" if self.max_voltage_start_time is None else "Absorption"
                     "Bulk"
                     if self.max_voltage_start_time is None
-                    else "Absorption" + "(tDiff: " + str(tDiff) + ")"
+                    else "Absorption"
                 )
 
             else:

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -102,8 +102,8 @@ class Battery(ABC):
         self.cells: List[Cell] = []
         self.control_charging = None
         self.control_voltage = None
-        self.max_battery_voltage = utils.MAX_CELL_VOLTAGE * self.cell_count
-        self.min_battery_voltage = utils.MIN_CELL_VOLTAGE * self.cell_count
+        self.max_battery_voltage = None
+        self.min_battery_voltage = None
         self.allow_max_voltage = True
         self.max_voltage_start_time = None
         self.charge_mode = None
@@ -198,6 +198,7 @@ class Battery(ABC):
         manages the charge voltage by setting self.control_voltage
         :return: None
         """
+        self.prepare_voltage_management()
         if utils.CVCM_ENABLE:
             if utils.LINEAR_LIMITATION_ENABLE:
                 self.manage_charge_voltage_linear()
@@ -207,6 +208,10 @@ class Battery(ABC):
         else:
             self.control_voltage = round(self.max_battery_voltage, 3)
             self.charge_mode = "Keep always max voltage"
+
+    def prepare_voltage_management(self) -> None:
+        self.max_battery_voltage = utils.MAX_CELL_VOLTAGE * self.cell_count
+        self.min_battery_voltage = utils.MIN_CELL_VOLTAGE * self.cell_count
 
     def manage_charge_voltage_linear(self) -> None:
         """

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -3,8 +3,6 @@ from battery import Battery, Cell
 from typing import Callable
 from utils import logger
 from bms.jkbms_brn import Jkbms_Brn
-from bleak import BleakScanner, BleakError
-import asyncio
 import time
 import os
 

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -30,7 +30,7 @@ class Jkbms_Ble(Battery):
         # Return True if success, False for failure
 
         logger.info("Test of Jkbms_Ble at " + self.jk.address)
-        
+
         # start scraping
         self.jk.start_scraping()
         tries = 1


### PR DESCRIPTION
This pull request introduces enhancements to the battery voltage management, specifically during the transition to the Linear Absorption mode. The main changes include:

1. Addition of `PENALTY_BUFFER` to the penalty sum calculation: This change ensures that the penalty sum calculation is more accurate, preventing overcharge of any single cell.

2. Resetting `self.max_voltage_start_time` when `voltageSum` falls below the maximum: This change addresses a specific scenario where a single cell's voltage exceeds the maximum while the total battery voltage (`voltageSum`) has not yet reached the maximum. In this case, `voltageSum` can fluctuate around the threshold value just before the start of Linear Absorption mode. By resetting `self.max_voltage_start_time` during a voltage drop, the code can more accurately track the start of the Linear Absorption mode.

These changes aim to improve the accuracy and efficiency of battery voltage management, particularly during the transition to Linear Absorption mode. They should help prevent overcharging of individual cells and ensure a smoother transition to Linear Absorption mode.
