### PR TITLE
Signal strength, unique identifier, persist custom name, many improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Added: JKBMS BLE - Show last five characters from the MAC address in the custom name (which is displayed in the device list) by @mr-manuel
 * Changed: Fixed error in `reinstall-local.sh` script for Bluetooth installation by @mr-manuel
 * Changed: Fixed typo in `config.ini` sample by @hoschult
+* Changed: Improved driver reinstall when multiple Bluetooth BMS are enabled by @mr-manuel
 * Changed: Improved Jkbms_Ble driver by @seidler2547 & @mr-manuel
+
 
 ## v1.0.20230531
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 ## v1.0.x
+* Added: Bluetooth: Show signal strenght of BMS in log by @mr-manuel
 * Added: Exclude a device from beeing used by the dbus-serialbattery driver by @mr-manuel
 * Added: Implement callback function for update by @seidler2547
-* Changed: Improved Jkbms_Ble driver by @seidler2547 & @mr-manuel
+* Added: JKBMS BLE - Show last five characters from the MAC address in the custom name (which is displayed in the device list) by @mr-manuel
+* Changed: Fixed error in `reinstall-local.sh` script for Bluetooth installation by @mr-manuel
 * Changed: Fixed typo in `config.ini` sample by @hoschult
+* Changed: Improved Jkbms_Ble driver by @seidler2547 & @mr-manuel
 
 ## v1.0.20230531
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v1.0.x
 * Added: Exclude a device from beeing used by the dbus-serialbattery driver by @mr-manuel
 * Added: Implement callback function for update by @seidler2547
+* Changed: Improved Jkbms_Ble driver by @seidler2547 & @mr-manuel
+* Changed: Fixed typo in `config.ini` sample by @hoschult
 
 ## v1.0.20230531
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added: Exclude a device from beeing used by the dbus-serialbattery driver by @mr-manuel
 * Added: Implement callback function for update by @seidler2547
 * Added: JKBMS BLE - Show last five characters from the MAC address in the custom name (which is displayed in the device list) by @mr-manuel
+* Added: Save custom name and make it restart persistant by @mr-manuel
 * Changed: Fixed error in `reinstall-local.sh` script for Bluetooth installation by @mr-manuel
 * Changed: Fixed typo in `config.ini` sample by @hoschult
 * Changed: Improved driver reinstall when multiple Bluetooth BMS are enabled by @mr-manuel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.x
 * Added: Bluetooth: Show signal strenght of BMS in log by @mr-manuel
+* Added: Create unique identifier, if not provided from BMS by @mr-manuel
 * Added: Exclude a device from beeing used by the dbus-serialbattery driver by @mr-manuel
 * Added: Implement callback function for update by @seidler2547
 * Added: JKBMS BLE - Show last five characters from the MAC address in the custom name (which is displayed in the device list) by @mr-manuel

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -71,14 +71,11 @@ class Battery(ABC):
         self.max_battery_discharge_current = None
         self.has_settings = 0
 
-        self.init_values()
-
-        # used to identify a BMS when multiple BMS are connected - planned for future use
-        self.unique_identifier = None
-
         # fetched from the BMS from a field where the user can input a custom string
         # only if available
         self.custom_field = None
+
+        self.init_values()
 
     def init_values(self):
         self.voltage = None
@@ -130,6 +127,20 @@ class Battery(ABC):
         # Each driver must override this function to test if a connection can be made
         # return false when failed, true if successful
         return False
+
+    def unique_identifier(self) -> str:
+        """
+        Used to identify a BMS when multiple BMS are connected
+        If not provided by the BMS/driver then the hardware version and capacity is used,
+        since it can be changed by small amounts to make a battery unique.
+        On +/- 5 Ah you can identify 11 batteries
+        """
+        return (
+            "".join(filter(str.isalnum, self.hardware_version))
+            + "_"
+            + str(self.capacity)
+            + "Ah"
+        )
 
     def connection_name(self) -> str:
         return "Serial " + self.port
@@ -1005,8 +1016,7 @@ class Battery(ABC):
         logger.info(
             f"> CCCM SOC: {str(utils.CCCM_SOC_ENABLE).ljust(5)} | DCCM SOC: {utils.DCCM_SOC_ENABLE}"
         )
-        if self.unique_identifier is not None:
-            logger.info(f"Serial Number/Unique Identifier: {self.unique_identifier}")
+        logger.info(f"Serial Number/Unique Identifier: {self.unique_identifier()}")
 
         return
 

--- a/etc/dbus-serialbattery/bms/battery_template.py
+++ b/etc/dbus-serialbattery/bms/battery_template.py
@@ -36,6 +36,15 @@ class BatteryTemplate(Battery):
 
         return result
 
+    def unique_identifier(self) -> str:
+        """
+        Used to identify a BMS when multiple BMS are connected
+        Provide a unique identifier from the BMS to identify a BMS, if multiple same BMS are connected
+        e.g. the serial number
+        If there is no such value, please remove this function
+        """
+        return self.serialnumber
+
     def get_settings(self):
         # After successful  connection get_settings will be call to set up the battery.
         # Set the current limits, populate cell count, etc
@@ -53,11 +62,6 @@ class BatteryTemplate(Battery):
         self.max_battery_voltage = utils.MAX_CELL_VOLTAGE * self.cell_count
         self.min_battery_voltage = utils.MIN_CELL_VOLTAGE * self.cell_count
 
-        # provide a unique identifier from the BMS to identify a BMS, if multiple same BMS are connected
-        # e.g. the serial number
-        # If there is no such value, please leave the line commented. In this case the capacity is used,
-        # since it can be changed by small amounts to make a battery unique. On +/- 5 Ah you can identify 11 batteries
-        # self.unique_identifier = str()
         return True
 
     def refresh_data(self):

--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -522,12 +522,16 @@ class Daly(Battery):
                 " ",
                 (battery_code.strip()),
             )
-            self.unique_identifier = self.custom_field.replace(" ", "_")
-        else:
-            self.unique_identifier = (
-                str(self.production) + "_" + str(int(self.capacity))
-            )
         return True
+
+    def unique_identifier(self) -> str:
+        """
+        Used to identify a BMS when multiple BMS are connected
+        """
+        if self.custom_field != "":
+            return self.custom_field.replace(" ", "_")
+        else:
+            return str(self.production) + "_" + str(int(self.capacity))
 
     def reset_soc_callback(self, path, value):
         if value is None:

--- a/etc/dbus-serialbattery/bms/heltecmodbus.py
+++ b/etc/dbus-serialbattery/bms/heltecmodbus.py
@@ -30,6 +30,7 @@ class HeltecModbus(Battery):
     def __init__(self, port, baud, address):
         super(HeltecModbus, self).__init__(port, baud, address)
         self.type = "Heltec_Smart"
+        self.unique_identifier_tmp = ""
 
     def test_connection(self):
         # call a function that will connect to the battery, send a command and retrieve the result.
@@ -174,7 +175,7 @@ class HeltecModbus(Battery):
                     time.sleep(SLPTIME)
 
                     serial1 = mbdev.read_registers(2, number_of_registers=4)
-                    self.unique_identifier = "-".join(
+                    self.unique_identifier_tmp = "-".join(
                         "{:04x}".format(x) for x in serial1
                     )
                     time.sleep(SLPTIME)
@@ -234,7 +235,7 @@ class HeltecModbus(Battery):
             logger.info(self.hardware_version)
             logger.info("Heltec-" + self.hwTypeName)
             logger.info("  Dev name: " + self.devName)
-            logger.info("  Serial: " + self.unique_identifier)
+            logger.info("  Serial: " + self.unique_identifier_tmp)
             logger.info("  Made on: " + self.production_date)
             logger.info("  Cell count: " + str(self.cell_count))
             logger.info("  Cell type: " + self.cellType)
@@ -244,6 +245,12 @@ class HeltecModbus(Battery):
             logger.info("  learned capacity: " + str(self.learned_capacity))
 
         return True
+
+    def unique_identifier(self) -> str:
+        """
+        Used to identify a BMS when multiple BMS are connected
+        """
+        return self.unique_identifier_tmp
 
     def read_soc_data(self):
         mbdev = mbdevs[self.address]

--- a/etc/dbus-serialbattery/bms/jkbms.py
+++ b/etc/dbus-serialbattery/bms/jkbms.py
@@ -10,6 +10,7 @@ class Jkbms(Battery):
     def __init__(self, port, baud, address):
         super(Jkbms, self).__init__(port, baud, address)
         self.type = self.BATTERYTYPE
+        self.unique_identifier_tmp = ""
 
     BATTERYTYPE = "Jkbms"
     LENGTH_CHECK = 1
@@ -184,9 +185,9 @@ class Jkbms(Battery):
         )[0].decode()
 
         offset = cellbyte_count + 197
-        self.unique_identifier = sub(
+        self.unique_identifier_tmp = sub(
             " +",
-            " ",
+            "_",
             (
                 unpack_from(">24s", self.get_data(status_data, b"\xBA", offset, 24))[0]
                 .decode()
@@ -208,6 +209,12 @@ class Jkbms(Battery):
 
         # logger.info(self.hardware_version)
         return True
+
+    def unique_identifier(self) -> str:
+        """
+        Used to identify a BMS when multiple BMS are connected
+        """
+        return self.unique_identifier_tmp
 
     def to_fet_bits(self, byte_data):
         tmp = bin(byte_data)[2:].rjust(3, utils.zero_char)

--- a/etc/dbus-serialbattery/bms/jkbms.py
+++ b/etc/dbus-serialbattery/bms/jkbms.py
@@ -126,6 +126,7 @@ class Jkbms(Battery):
             unpack_from(">H", self.get_data(status_data, b"\x99", offset, 2))[0]
         )
 
+        # the JKBMS resets to 95% SoC, if all cell voltages are above or equal to 3.500 V
         offset = cellbyte_count + 18
         self.soc = unpack_from(">B", self.get_data(status_data, b"\x85", offset, 1))[0]
 

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -2,11 +2,12 @@
 from battery import Battery, Cell
 from typing import Callable
 from utils import logger
+from time import sleep, time
 from bms.jkbms_brn import Jkbms_Brn
-from bleak import BleakScanner, BleakError
-import asyncio
-import time
 import os
+
+# from bleak import BleakScanner, BleakError
+# import asyncio
 
 
 class Jkbms_Ble(Battery):
@@ -28,34 +29,46 @@ class Jkbms_Ble(Battery):
         # call a function that will connect to the battery, send a command and retrieve the result.
         # The result or call should be unique to this BMS. Battery name or version, etc.
         # Return True if success, False for failure
+        result = False
+        logger.info("Test of Jkbms_Ble at " + self.address)
+        try:
+            if self.address and self.address != "":
+                result = True
 
-        logger.info("Test of Jkbms_Ble at " + self.jk.address)
-        
-        # start scraping
-        self.jk.start_scraping()
-        tries = 1
+            if result:
+                # start scraping
+                self.jk.start_scraping()
+                tries = 1
 
-        while self.jk.get_status() is None and tries < 20:
-            time.sleep(0.5)
-            tries += 1
+                while self.jk.get_status() is None and tries < 20:
+                    sleep(0.5)
+                    tries += 1
 
-        # load initial data, from here on get_status has valid values to be served to the dbus
-        status = self.jk.get_status()
-        if status is None:
-            self.jk.stop_scraping()
-            return False
+                # load initial data, from here on get_status has valid values to be served to the dbus
+                status = self.jk.get_status()
 
-        if not status["device_info"]["vendor_id"].startswith(("JK-", "JK_")):
-            self.jk.stop_scraping()
-            return False
+                if status is None:
+                    self.jk.stop_scraping()
+                    result = False
 
-        logger.info("Jkbms_Ble found!")
+                if result and not status["device_info"]["vendor_id"].startswith(
+                    ("JK-", "JK_")
+                ):
+                    self.jk.stop_scraping()
+                    result = False
 
-        # get first data to show in startup log
-        self.get_settings()
-        self.refresh_data()
+                # get first data to show in startup log
+                if result:
+                    self.get_settings()
+                    self.refresh_data()
+            if not result:
+                logger.error("No BMS found at " + self.address)
 
-        return True
+        except Exception as err:
+            logger.error(f"Unexpected {err=}, {type(err)=}")
+            result = False
+
+        return result
 
     def get_settings(self):
         # After successful  connection get_settings will be call to set up the battery.
@@ -107,16 +120,17 @@ class Jkbms_Ble(Battery):
         st = self.jk.get_status()
         if st is None:
             return False
-        if time.time() - st["last_update"] > 30:
-            # if data not updated for more than 30s, sth is wrong, then fail
-            logger.info("Jkbms_Ble: Bluetooth died")
 
-            # if the thread is still alive but data too old there is sth
+        if time() - st["last_update"] >= 60:
+            # if data not updated for more than 60s, something is wrong, then fail
+            logger.info("Jkbms_Ble: Bluetooth died. Got no fresh data since 60s.")
+
+            # if the thread is still alive but data too old there is something
             # wrong with the bt-connection; restart whole stack
             if not self.resetting:
                 self.reset_bluetooth()
                 self.jk.start_scraping()
-                time.sleep(2)
+                sleep(2)
 
             return False
         else:
@@ -193,20 +207,21 @@ class Jkbms_Ble(Battery):
         return True
 
     def reset_bluetooth(self):
-        logger.info("Reset of Bluetooth triggered")
+        logger.info("Reset of system Bluetooth daemon triggered")
         self.resetting = True
-        # if self.jk.is_running():
-        # self.jk.stop_scraping()
+        if self.jk.is_running():
+            self.jk.stop_scraping()
+
         logger.info("Scraping ended, issuing sys-commands")
         # process kill is needed, since the service/bluetooth driver is probably freezed
         os.system('pkill -f "bluetoothd"')
         # stop will not work, if service/bluetooth driver is stuck
         # os.system("/etc/init.d/bluetooth stop")
-        time.sleep(2)
+        sleep(2)
         os.system("rfkill block bluetooth")
         os.system("rfkill unblock bluetooth")
         os.system("/etc/init.d/bluetooth start")
-        logger.info("Bluetooth should have been restarted")
+        logger.info("System Bluetooth daemon should have been restarted")
 
     def get_balancing(self):
         return 1 if self.balancing else 0

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -19,6 +19,7 @@ class Jkbms_Ble(Battery):
         self.address = address
         self.type = self.BATTERYTYPE
         self.jk = Jkbms_Brn(address)
+        self.unique_identifier_tmp = ""
 
         logger.info("Init of Jkbms_Ble at " + address)
 
@@ -91,7 +92,9 @@ class Jkbms_Ble(Battery):
         tmp = self.jk.get_status()["device_info"]["manufacturing_date"]
         self.production = "20" + tmp if tmp and tmp != "" else None
 
-        self.unique_identifier = self.jk.get_status()["device_info"]["serial_number"]
+        self.unique_identifier_tmp = self.jk.get_status()["device_info"][
+            "serial_number"
+        ]
 
         for c in range(self.cell_count):
             self.cells.append(Cell(False))
@@ -108,6 +111,12 @@ class Jkbms_Ble(Battery):
         )
         logger.info("BAT: " + self.hardware_version)
         return True
+
+    def unique_identifier(self) -> str:
+        """
+        Used to identify a BMS when multiple BMS are connected
+        """
+        return self.unique_identifier_tmp
 
     def use_callback(self, callback: Callable) -> bool:
         self.jk.set_callback(callback)

--- a/etc/dbus-serialbattery/bms/jkbms_brn.py
+++ b/etc/dbus-serialbattery/bms/jkbms_brn.py
@@ -1,9 +1,8 @@
-import asyncio
-from bleak import BleakScanner, BleakClient
-import time
-from logging import info, debug
-import logging
 from struct import unpack_from, calcsize
+from bleak import BleakScanner, BleakClient
+from time import sleep, time
+import asyncio
+import logging
 import threading
 
 logging.basicConfig(level=logging.INFO)
@@ -191,19 +190,19 @@ class Jkbms_Brn:
         for t in TRANSLATE_CELL_INFO:
             self.translate(fb, t, self.bms_status, f32s=has32s)
         self.decode_warnings(fb)
-        debug(self.bms_status)
+        logging.debug(self.bms_status)
 
     def decode_settings_jk02(self):
         fb = self.frame_buffer
         for t in TRANSLATE_SETTINGS:
             self.translate(fb, t, self.bms_status)
-        debug(self.bms_status)
+        logging.debug(self.bms_status)
 
     def decode(self):
         # check what kind of info the frame contains
         info_type = self.frame_buffer[4]
         if info_type == 0x01:
-            info("Processing frame with settings info")
+            logging.info("Processing frame with settings info")
             if protocol_version == PROTOCOL_VERSION_JK02:
                 self.decode_settings_jk02()
                 # adapt translation table for cell array lengths
@@ -211,18 +210,18 @@ class Jkbms_Brn:
                 for i, t in enumerate(TRANSLATE_CELL_INFO):
                     if t[0][-2] == "voltages" or t[0][-2] == "voltages":
                         TRANSLATE_CELL_INFO[i][0][-1] = ccount
-                self.bms_status["last_update"] = time.time()
+                self.bms_status["last_update"] = time()
 
         elif info_type == 0x02:
             if (
                 CELL_INFO_REFRESH_S == 0
-                or time.time() - self.last_cell_info > CELL_INFO_REFRESH_S
+                or time() - self.last_cell_info > CELL_INFO_REFRESH_S
             ):
-                self.last_cell_info = time.time()
-                info("processing frame with battery cell info")
+                self.last_cell_info = time()
+                logging.info("processing frame with battery cell info")
                 if protocol_version == PROTOCOL_VERSION_JK02:
                     self.decode_cellinfo_jk02()
-                    self.bms_status["last_update"] = time.time()
+                    self.bms_status["last_update"] = time()
                 # power is calculated from voltage x current as
                 # register 122 contains unsigned power-value
                 self.bms_status["cell_info"]["power"] = (
@@ -233,10 +232,10 @@ class Jkbms_Brn:
                     self.waiting_for_response = ""
 
         elif info_type == 0x03:
-            info("processing frame with device info")
+            logging.info("processing frame with device info")
             if protocol_version == PROTOCOL_VERSION_JK02:
                 self.decode_device_info_jk02()
-                self.bms_status["last_update"] = time.time()
+                self.bms_status["last_update"] = time()
             else:
                 return
             if self.waiting_for_response == "device_info":
@@ -247,7 +246,9 @@ class Jkbms_Brn:
 
     def assemble_frame(self, data: bytearray):
         if len(self.frame_buffer) > MAX_RESPONSE_SIZE:
-            info("data dropped because it alone was longer than max frame length")
+            logging.info(
+                "data dropped because it alone was longer than max frame length"
+            )
             self.frame_buffer = []
 
         if data[0] == 0x55 and data[1] == 0xAA and data[2] == 0xEB and data[3] == 0x90:
@@ -261,16 +262,16 @@ class Jkbms_Brn:
             # actual frame-lentgh, so crc up to 299
             ccrc = self.crc(self.frame_buffer, 300 - 1)
             rcrc = self.frame_buffer[300 - 1]
-            debug(f"compair recvd. crc: {rcrc} vs calc. crc: {ccrc}")
+            logging.debug(f"compair recvd. crc: {rcrc} vs calc. crc: {ccrc}")
             if ccrc == rcrc:
-                debug("great success! frame complete and sane, lets decode")
+                logging.debug("great success! frame complete and sane, lets decode")
                 self.decode()
                 self.frame_buffer = []
                 if self._new_data_callback is not None:
                     self._new_data_callback()
 
     def ncallback(self, sender: int, data: bytearray):
-        debug(f"------> NEW PACKAGE!laenge:  {len(data)}")
+        logging.debug(f"------> NEW PACKAGE!laenge:  {len(data)}")
         self.assemble_frame(data)
 
     def crc(self, arr: bytearray, length: int) -> int:
@@ -303,13 +304,13 @@ class Jkbms_Brn:
         frame[17] = 0x00
         frame[18] = 0x00
         frame[19] = self.crc(frame, len(frame) - 1)
-        debug("Write register: ", frame)
+        logging.debug("Write register: ", frame)
         await bleakC.write_gatt_char(CHAR_HANDLE, frame, False)
 
     async def request_bt(self, rtype: str, client):
-        timeout = time.time()
+        timeout = time()
 
-        while self.waiting_for_response != "" and time.time() - timeout < 10:
+        while self.waiting_for_response != "" and time() - timeout < 10:
             await asyncio.sleep(1)
             print(self.waiting_for_response)
 
@@ -351,18 +352,18 @@ class Jkbms_Brn:
 
                 await self.request_bt("cell_info", client)
                 # await self.enable_charging(client)
-                # last_dev_info = time.time()
+                # last_dev_info = time()
                 while client.is_connected and self.run and self.main_thread.is_alive():
                     await asyncio.sleep(0.01)
             except Exception as e:
-                info("error while connecting to bt: " + str(e))
+                logging.info("error while connecting to bt: " + str(e))
                 self.run = False
             finally:
                 if client.is_connected:
                     try:
                         await client.disconnect()
                     except Exception as e:
-                        info("error while disconnecting: " + str(e))
+                        logging.info("error while disconnecting: " + str(e))
 
         print("Exiting bt-loop")
 
@@ -371,7 +372,7 @@ class Jkbms_Brn:
         if self.is_running():
             return
         self.bt_thread.start()
-        info(
+        logging.info(
             "scraping thread started -> main thread id: "
             + str(self.main_thread.ident)
             + " scraping thread: "
@@ -380,10 +381,10 @@ class Jkbms_Brn:
 
     def stop_scraping(self):
         self.run = False
-        stop = time.time()
+        stop = time()
         while self.is_running():
-            time.sleep(0.1)
-            if time.time() - stop > 10:
+            sleep(0.1)
+            if time() - stop > 10:
                 return False
         return True
 
@@ -407,5 +408,5 @@ if __name__ == "__main__":
     jk.start_scraping()
     while True:
         print(jk.get_status())
-        time.sleep(5)
+        sleep(5)
 """

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -195,6 +195,12 @@ BMS_TYPE =
 ; Example: /dev/ttyUSB2, /dev/ttyUSB4
 EXCLUDED_DEVICES =
 
+; Enter custom battery names here or change it over the GUI
+; Example:
+;     /dev/ttyUSB0:My first battery
+;     /dev/ttyUSB0:My first battery,/dev/ttyUSB1:My second battery
+CUSTOM_BATTERY_NAMES =
+
 ; Publish the config settings to the dbus path "/Info/Config/"
 PUBLISH_CONFIG_VALUES = 1
 

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -114,7 +114,7 @@ def main():
         else:
             # just for MNB-SPI
             logger.info("No Port needed")
-            return "/dev/tty/USB9"
+            return "/dev/ttyUSB9"
 
     logger.info("dbus-serialbattery v" + str(utils.DRIVER_VERSION))
 

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -58,7 +58,7 @@ expected_bms_types = [
     if battery_type["bms"].__name__ == utils.BMS_TYPE or utils.BMS_TYPE == ""
 ]
 
-print("")
+logger.info("")
 logger.info("Starting dbus-serialbattery")
 
 

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -123,7 +123,10 @@ class DbusHelper:
         self._dbusservice.add_path("/HardwareVersion", self.battery.hardware_version)
         self._dbusservice.add_path("/Connected", 1)
         self._dbusservice.add_path(
-            "/CustomName", self.battery.custom_name(), writeable=True
+            "/CustomName",
+            self.battery.custom_name(),
+            writeable=True,
+            onchangecallback=self.battery.custom_name_callback,
         )
         self._dbusservice.add_path(
             "/Serial", self.battery.unique_identifier, writeable=True

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -129,7 +129,7 @@ class DbusHelper:
             onchangecallback=self.battery.custom_name_callback,
         )
         self._dbusservice.add_path(
-            "/Serial", self.battery.unique_identifier, writeable=True
+            "/Serial", self.battery.unique_identifier(), writeable=True
         )
         self._dbusservice.add_path(
             "/DeviceName", self.battery.custom_field, writeable=True

--- a/etc/dbus-serialbattery/disable.sh
+++ b/etc/dbus-serialbattery/disable.sh
@@ -16,8 +16,8 @@ rm -rf /service/dbus-serialbattery.*
 rm -rf /service/dbus-blebattery.*
 
 # kill driver, if running
-pkill -f "python .*/dbus-serialbattery.py"
-pkill -f "blebattery"
+pkill -f "dbus-serialbattery"
+pkill -f "dbus-blebattery"
 
 # remove install script from rc.local
 sed -i "/bash \/data\/etc\/dbus-serialbattery\/reinstall-local.sh/d" /data/rc.local

--- a/etc/dbus-serialbattery/reinstall-local.sh
+++ b/etc/dbus-serialbattery/reinstall-local.sh
@@ -3,8 +3,6 @@
 # remove comment for easier troubleshooting
 #set -x
 
-DRIVERNAME=dbus-serialbattery
-
 
 # check if minimum required Venus OS is installed | start
 versionRequired="v2.90"
@@ -66,15 +64,15 @@ fi
 bash /opt/victronenergy/swupdate-scripts/remount-rw.sh
 
 # install
-rm -rf /opt/victronenergy/service/$DRIVERNAME
-rm -rf /opt/victronenergy/service-templates/$DRIVERNAME
-rm -rf /opt/victronenergy/$DRIVERNAME
-mkdir /opt/victronenergy/$DRIVERNAME
-mkdir /opt/victronenergy/$DRIVERNAME/bms
-cp -f /data/etc/$DRIVERNAME/* /opt/victronenergy/$DRIVERNAME &>/dev/null
-cp -f /data/etc/$DRIVERNAME/bms/* /opt/victronenergy/$DRIVERNAME/bms &>/dev/null
-cp -rf /data/etc/$DRIVERNAME/service /opt/victronenergy/service-templates/$DRIVERNAME
-bash /data/etc/$DRIVERNAME/install-qml.sh
+rm -rf /opt/victronenergy/service/dbus-serialbattery
+rm -rf /opt/victronenergy/service-templates/dbus-serialbattery
+rm -rf /opt/victronenergy/dbus-serialbattery
+mkdir /opt/victronenergy/dbus-serialbattery
+mkdir /opt/victronenergy/dbus-serialbattery/bms
+cp -f /data/etc/dbus-serialbattery/* /opt/victronenergy/dbus-serialbattery &>/dev/null
+cp -f /data/etc/dbus-serialbattery/bms/* /opt/victronenergy/dbus-serialbattery/bms &>/dev/null
+cp -rf /data/etc/dbus-serialbattery/service /opt/victronenergy/service-templates/dbus-serialbattery
+bash /data/etc/dbus-serialbattery/install-qml.sh
 
 # check if serial-starter.d was deleted
 serialstarter_path="/data/conf/serial-starter.d"
@@ -105,10 +103,10 @@ if [ ! -f "$filename" ]; then
     echo "#!/bin/bash" > "$filename"
     chmod 755 "$filename"
 fi
-grep -qxF "bash /data/etc/$DRIVERNAME/reinstall-local.sh" $filename || echo "bash /data/etc/$DRIVERNAME/reinstall-local.sh" >> $filename
+grep -qxF "bash /data/etc/dbus-serialbattery/reinstall-local.sh" $filename || echo "bash /data/etc/dbus-serialbattery/reinstall-local.sh" >> $filename
 
 # add empty config.ini, if it does not exist to make it easier for users to add custom settings
-filename="/data/etc/$DRIVERNAME/config.ini"
+filename="/data/etc/dbus-serialbattery/config.ini"
 if [ ! -f "$filename" ]; then
     {
         echo "[DEFAULT]"
@@ -123,6 +121,9 @@ if [ ! -f "$filename" ]; then
         echo
     } > $filename
 fi
+
+# kill driver, if running. It gets restarted by the service daemon
+pkill -f "python .*/dbus-serialbattery.py$"
 
 
 
@@ -144,11 +145,17 @@ IFS="," read -r -a bms_array <<< "$bluetooth_bms_clean"
 length=${#bms_array[@]}
 # echo $length
 
+# stop all dbus-blebattery services
+svc -u /service/dbus-blebattery.*
+
 # always remove existing blebattery services to cleanup
 rm -rf /service/dbus-blebattery.*
 
-# kill all blebattery processes
-pkill -f "blebattery"
+# kill all blebattery processes that remain
+pkill -f "supervise dbus-blebattery.*"
+pkill -f "multilog .* /var/log/dbus-blebattery.*"
+pkill -f "python .*/dbus-serialbattery.py .*_Ble"
+
 
 if [ "$length" -gt 0 ]; then
 
@@ -201,10 +208,12 @@ if [ "$length" -gt 0 ]; then
             echo "echo \"INFO:Bluetooth details\""
             # close all open connections, else the driver can't connect
             echo "bluetoothctl disconnect $3"
+
             # enable bluetoothctl scan in background to display signal strength (RSSI), else it's missing
             echo "bluetoothctl scan on | grep \"$3\" | grep \"RSSI\" &"
-            # with multiple Bluetooth BMS one scan for all would be enough. Check if that can be changed globally, maybe with a cronjob after reboot
+            # with multiple Bluetooth BMS one scan for all should be enough. Check if that can be changed globally, maybe with a cronjob after reboot?
             # echo "bluetoothctl scan on > /dev/null &"
+
             # wait 5 seconds to finish the scan
             echo "sleep 5"
             # display some Bluetooth device details
@@ -256,15 +265,6 @@ sed -i "/^sh \/data\/etc\/dbus-serialbattery\/reinstall-local.sh/d" /data/rc.loc
 sed -i "/^sh \/data\/etc\/dbus-serialbattery\/installble.sh/d" /data/rc.local
 ### needed for upgrading from older versions | end ###
 
-
-# kill driver, if running. It gets restarted by the service daemon
-pkill -f "python .*/$DRIVERNAME.py"
-
-# restart bluetooth service, if Bluetooth BMS configured
-if [ "$length" -gt 0 ]; then
-    /etc/init.d/bluetooth restart
-    echo
-fi
 
 
 # install notes

--- a/etc/dbus-serialbattery/reinstall-local.sh
+++ b/etc/dbus-serialbattery/reinstall-local.sh
@@ -123,7 +123,7 @@ if [ ! -f "$filename" ]; then
 fi
 
 # kill driver, if running. It gets restarted by the service daemon
-pkill -f "python .*/dbus-serialbattery.py$"
+pkill -f "python .*/dbus-serialbattery.py /dev/tty.*"
 
 
 
@@ -145,16 +145,18 @@ IFS="," read -r -a bms_array <<< "$bluetooth_bms_clean"
 length=${#bms_array[@]}
 # echo $length
 
-# stop all dbus-blebattery services
-svc -u /service/dbus-blebattery.*
+# stop all dbus-blebattery services, if at least one exists
+if [ -d "/service/dbus-blebattery.0" ]; then
+    svc -u /service/dbus-blebattery.*
 
-# always remove existing blebattery services to cleanup
-rm -rf /service/dbus-blebattery.*
+    # always remove existing blebattery services to cleanup
+    rm -rf /service/dbus-blebattery.*
 
-# kill all blebattery processes that remain
-pkill -f "supervise dbus-blebattery.*"
-pkill -f "multilog .* /var/log/dbus-blebattery.*"
-pkill -f "python .*/dbus-serialbattery.py .*_Ble"
+    # kill all blebattery processes that remain
+    pkill -f "supervise dbus-blebattery.*"
+    pkill -f "multilog .* /var/log/dbus-blebattery.*"
+    pkill -f "python .*/dbus-serialbattery.py .*_Ble"
+fi
 
 
 if [ "$length" -gt 0 ]; then
@@ -247,6 +249,7 @@ else
     # remove cronjob
     sed -i "/5 0,12 \* \* \* \/etc\/init.d\/bluetooth restart/d" /var/spool/cron/root
 
+    echo
     echo "No Bluetooth battery configuration found in \"/data/etc/dbus-serialbattery/config.ini\"."
     echo "You can ignore this, if you are using only a serial connection."
     echo

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -38,7 +38,7 @@ def _get_list_from_config(
 # if not specified: baud = 9600
 
 # Constants - Need to dynamically get them in future
-DRIVER_VERSION = "1.0.20230526dev"
+DRIVER_VERSION = "1.0.20230608dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -15,10 +15,13 @@ logging.basicConfig()
 logger = logging.getLogger("SerialBattery")
 logger.setLevel(logging.INFO)
 
+PATH_CONFIG_DEFAULT = "config.default.ini"
+PATH_CONFIG_USER = "config.ini"
+
 config = configparser.ConfigParser()
 path = Path(__file__).parents[0]
-default_config_file_path = path.joinpath("config.default.ini").absolute().__str__()
-custom_config_file_path = path.joinpath("config.ini").absolute().__str__()
+default_config_file_path = path.joinpath(PATH_CONFIG_DEFAULT).absolute().__str__()
+custom_config_file_path = path.joinpath(PATH_CONFIG_USER).absolute().__str__()
 config.read([default_config_file_path, custom_config_file_path])
 
 
@@ -275,8 +278,18 @@ TIME_TO_SOC_INC_FROM = "True" == config["DEFAULT"]["TIME_TO_SOC_INC_FROM"]
 # Ant, MNB, Sinowealth
 BMS_TYPE = config["DEFAULT"]["BMS_TYPE"]
 
+# Exclute this serial devices from the driver startup
+# Example: /dev/ttyUSB2, /dev/ttyUSB4
 EXCLUDED_DEVICES = _get_list_from_config(
     "DEFAULT", "EXCLUDED_DEVICES", lambda v: str(v)
+)
+
+# Enter custom battery names here or change it over the GUI
+# Example:
+#     /dev/ttyUSB0:My first battery
+#     /dev/ttyUSB0:My first battery, /dev/ttyUSB1:My second battery
+CUSTOM_BATTERY_NAMES = _get_list_from_config(
+    "DEFAULT", "CUSTOM_BATTERY_NAMES", lambda v: str(v)
 )
 
 # Publish the config settings to the dbus path "/Info/Config/"
@@ -526,6 +539,7 @@ def read_serialport_data(
 locals_copy = locals().copy()
 
 
+# Publish config variables to dbus
 def publish_config_variables(dbusservice):
     for variable, value in locals_copy.items():
         if variable.startswith("__"):

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -38,7 +38,7 @@ def _get_list_from_config(
 # if not specified: baud = 9600
 
 # Constants - Need to dynamically get them in future
-DRIVER_VERSION = "1.0.20230608dev"
+DRIVER_VERSION = "1.0.20230610dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 


### PR DESCRIPTION
* Added: Bluetooth: Show signal strenght of BMS in log by @mr-manuel
* Added: Create unique identifier, if not provided from BMS by @mr-manuel
* Added: JKBMS BLE - Show last five characters from the MAC address in the custom name (which is displayed in the device list) by @mr-manuel
* Added: Save custom name and make it restart persistant (fix #100) by @mr-manuel
* Changed: Fixed error in `reinstall-local.sh` script for Bluetooth installation by @mr-manuel
* Changed: Fixed typo in `config.ini` sample by @hoschult
* Changed: Improved driver reinstall when multiple Bluetooth BMS are enabled by @mr-manuel
* Changed: Improved Jkbms_Ble driver by @seidler2547 & @mr-manuel