### PR TITLE
This changes how strict we are about the accepted return data length for the requests to the BMS

### DIFF
--- a/etc/dbus-serialbattery/bms/seplos.py
+++ b/etc/dbus-serialbattery/bms/seplos.py
@@ -115,7 +115,6 @@ class Seplos(Battery):
         # This will be called for every iteration (self.poll_interval)
         # Return True if success, False for failure
         result_status = self.read_status_data()
-        # sleep(0.5)
         result_alarm = self.read_alarm_data()
 
         return result_status and result_alarm
@@ -129,15 +128,20 @@ class Seplos(Battery):
         return Protection.OK
 
     def read_alarm_data(self):
+        logger.debug("read alarm data")
         data = self.read_serial_data_seplos(
             self.encode_cmd(address=0x00, cid2=self.COMMAND_ALARM, info=b"01")
         )
-        # check if connection success
-        if data is False:
+        # check if we could successfully read data and we have the expected length of 98 bytes
+        if data is False or len(data) != 98:
             return False
 
-        logger.debug("alarm info raw {}".format(data))
-        return self.decode_alarm_data(bytes.fromhex(data.decode("ascii")))
+        try:
+            logger.debug("alarm info raw {}".format(data))
+            return self.decode_alarm_data(bytes.fromhex(data.decode("ascii")))
+        except (ValueError, UnicodeDecodeError) as e:
+            logger.warning("could not hex-decode raw alarm data", exc_info = e)
+            return False
 
     def decode_alarm_data(self, data: bytes):
         logger.debug("alarm info decoded {}".format(data))
@@ -191,14 +195,20 @@ class Seplos(Battery):
 
     def read_status_data(self):
         logger.debug("read status data")
+
         data = self.read_serial_data_seplos(
             self.encode_cmd(address=0x00, cid2=0x42, info=b"01")
         )
 
-        # check if connection success
-        if data is False:
+        # check if reading data was successful and has the expected data length of 150 byte
+        if data is False or len(data) != 150:
             return False
 
+        self.decode_status_data(data)
+
+        return True
+
+    def decode_status_data(self, data):
         cell_count_offset = 4
         voltage_offset = 6
         temps_offset = 72
@@ -218,7 +228,6 @@ class Seplos(Battery):
                 ) / 10
                 self.cells[i].temp = temp
                 logger.debug("Temp cell[{}]={}°C".format(i, temp))
-
         self.temp1 = (
             Seplos.int_from_2byte_hex_ascii(data, temps_offset + 4 * 4) - 2731
         ) / 10
@@ -234,7 +243,6 @@ class Seplos(Battery):
         self.soc = Seplos.int_from_2byte_hex_ascii(data, offset=114) / 10
         self.cycles = Seplos.int_from_2byte_hex_ascii(data, offset=122)
         self.hardware_version = "Seplos BMS {} cells".format(self.cell_count)
-
         logger.debug("Current = {}A , Voltage = {}V".format(self.current, self.voltage))
         logger.debug(
             "Capacity = {}/{}Ah , SOC = {}%".format(
@@ -249,7 +257,6 @@ class Seplos(Battery):
         )
         logger.debug("HW:" + self.hardware_version)
 
-        return True
 
     @staticmethod
     def is_valid_frame(data: bytes) -> bool:
@@ -260,7 +267,7 @@ class Seplos(Battery):
         * not checked: lchksum
         """
         if len(data) < 18:
-            logger.debug("short read, data={}".format(data))
+            logger.warning("short read, data={}".format(data))
             return False
 
         chksum = Seplos.get_checksum(data[1:-5])
@@ -297,7 +304,7 @@ class Seplos(Battery):
             return_data = data[length_pos + 3 : -5]
             info_length = Seplos.int_from_2byte_hex_ascii(b"0" + data[length_pos:], 0)
             logger.debug(
-                "return info data of length {} : {}".format(info_length, return_data)
+                "returning info data of length {}, info_length is {} : {}".format(len(return_data), info_length, return_data)
             )
 
             return return_data

--- a/etc/dbus-serialbattery/bms/seplos.py
+++ b/etc/dbus-serialbattery/bms/seplos.py
@@ -140,7 +140,7 @@ class Seplos(Battery):
             logger.debug("alarm info raw {}".format(data))
             return self.decode_alarm_data(bytes.fromhex(data.decode("ascii")))
         except (ValueError, UnicodeDecodeError) as e:
-            logger.warning("could not hex-decode raw alarm data", exc_info = e)
+            logger.warning("could not hex-decode raw alarm data", exc_info=e)
             return False
 
     def decode_alarm_data(self, data: bytes):
@@ -257,7 +257,6 @@ class Seplos(Battery):
         )
         logger.debug("HW:" + self.hardware_version)
 
-
     @staticmethod
     def is_valid_frame(data: bytes) -> bool:
         """checks if data contains a valid frame
@@ -304,7 +303,9 @@ class Seplos(Battery):
             return_data = data[length_pos + 3 : -5]
             info_length = Seplos.int_from_2byte_hex_ascii(b"0" + data[length_pos:], 0)
             logger.debug(
-                "returning info data of length {}, info_length is {} : {}".format(len(return_data), info_length, return_data)
+                "returning info data of length {}, info_length is {} : {}".format(
+                    len(return_data), info_length, return_data
+                )
             )
 
             return return_data


### PR DESCRIPTION
Maybe this is enough to fix the problems with grid meters accidentally being recognized as Seplos BMSs. 