### PR TITLE
Introduction of automatic SOC reset for JK BMS Bluetooth only (HW Version 11)

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -275,6 +275,9 @@ class Battery(ABC):
                     and self.allow_max_voltage
                 ):
                     self.max_voltage_start_time = int(time())
+                    # Assume battery SOC ist 100% at this stage
+                    # Function for each battery that supports reset of SOC
+                    self.trigger_soc_reset()
 
                 # allow max voltage again, if cells are unbalanced or SoC threshold is reached
                 elif (
@@ -289,7 +292,7 @@ class Battery(ABC):
                 if 300 < tDiff:
                     self.allow_max_voltage = False
                     self.max_voltage_start_time = None
-                # we don't forget to reset max_voltage_start_time wenn we going to bulk(dynamic) mode
+                # we don't forget to reset max_voltage_start_time when we going to bulk(dynamic) mode
                 # regardless of whether we were in absorption mode or not
                 if (
                     voltageSum
@@ -417,6 +420,9 @@ class Battery(ABC):
                 ):
                     # example 2
                     self.max_voltage_start_time = time()
+                    # Assume battery SOC ist 100% at this stage
+                    # Function for each battery that supports reset of SOC
+                    self.trigger_soc_reset()
 
                 # check if reset soc is greater than battery soc
                 # this prevents flapping between max and float voltage
@@ -1094,6 +1100,19 @@ class Battery(ABC):
         logger.info(
             f"> CCCM SOC: {str(utils.CCCM_SOC_ENABLE).ljust(5)} | DCCM SOC: {utils.DCCM_SOC_ENABLE}"
         )
+        if utils.AUTO_RESET_SOC and utils.JK_BMS_AUTO_RESET_SOC:
+            logger.info("JK BMS SOC reset enabled")
+            logger.info(
+                f"> OVPR default: {str(utils.JK_BMS_OVPR_DEFAULT)}V | OVP default: {utils.JK_BMS_OVP_DEFAULT}V"
+            )
+            logger.info(
+                f"> OVPR trigger: {str(utils.JK_BMS_OVPR_TRIGGER_RESET)}V | OVP trigger: {utils.JK_BMS_OVP_TRIGGER_RESET}V"
+            )
+            logger.info(
+                f"> Timeout to next possible SOC reset: {str(utils.JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET)}"
+            )
+        else:
+            logger.info("JK BMS SOC reset disabled")
         logger.info(f"Serial Number/Unique Identifier: {self.unique_identifier()}")
 
         return
@@ -1249,4 +1268,10 @@ class Battery(ABC):
         return
 
     def turn_balancing_off_callback(self, path, value):
+        return
+
+    def trigger_soc_reset(self):
+        """
+        This method can be used to implement SOC reset when the battery is assumed to be full
+        """
         return

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -278,9 +278,6 @@ class Battery(ABC):
                     and self.allow_max_voltage
                 ):
                     self.max_voltage_start_time = current_time
-                    # Assume battery SOC ist 100% at this stage
-                    # Function for each battery that supports reset of SOC
-                    self.trigger_soc_reset()
 
                 # allow max voltage again, if cells are unbalanced or SoC threshold is reached
                 elif (
@@ -355,6 +352,8 @@ class Battery(ABC):
                         self.transition_start_time = current_time
                         self.initial_control_voltage = self.control_voltage
                         chargeMode = "Float Transition"
+                        # Assume battery SOC ist 100% at this stage
+                        self.trigger_soc_reset()
                     elif self.charge_mode.startswith("Float Transition"):
                         elapsed_time = current_time - self.transition_start_time
                         # Voltage reduction per second
@@ -452,9 +451,6 @@ class Battery(ABC):
                 ):
                     # example 2
                     self.max_voltage_start_time = time()
-                    # Assume battery SOC ist 100% at this stage
-                    # Function for each battery that supports reset of SOC
-                    self.trigger_soc_reset()
 
                 # check if reset soc is greater than battery soc
                 # this prevents flapping between max and float voltage
@@ -1132,19 +1128,6 @@ class Battery(ABC):
         logger.info(
             f"> CCCM SOC: {str(utils.CCCM_SOC_ENABLE).ljust(5)} | DCCM SOC: {utils.DCCM_SOC_ENABLE}"
         )
-        if utils.AUTO_RESET_SOC and utils.JK_BMS_AUTO_RESET_SOC:
-            logger.info("JK BMS SOC reset enabled")
-            logger.info(
-                f"> OVPR default: {str(utils.JK_BMS_OVPR_DEFAULT)}V | OVP default: {utils.JK_BMS_OVP_DEFAULT}V"
-            )
-            logger.info(
-                f"> OVPR trigger: {str(utils.JK_BMS_OVPR_TRIGGER_RESET)}V | OVP trigger: {utils.JK_BMS_OVP_TRIGGER_RESET}V"
-            )
-            logger.info(
-                f"> Timeout to next possible SOC reset: {str(utils.JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET)}"
-            )
-        else:
-            logger.info("JK BMS SOC reset disabled")
         logger.info(f"Serial Number/Unique Identifier: {self.unique_identifier()}")
 
         return

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -90,7 +90,6 @@ class Jkbms_Ble(Battery):
         if self.jk.ovp_initial_voltage is None or self.jk.ovpr_initial_voltage is None:
             self.jk.ovp_initial_voltage = st["cell_ovp"]
             self.jk.ovpr_initial_voltage = st["cell_ovpr"]
-            logger.error("Persisting OVP: " + str(self.jk.ovp_initial_voltage) + " and OVPR: " + str(self.jk.ovpr_initial_voltage))
 
         # "User Private Data" field in APP
         tmp = self.jk.get_status()["device_info"]["production"]

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -258,6 +258,10 @@ class Jkbms_Ble(Battery):
 
     def trigger_soc_reset(self):
         if utils.AUTO_RESET_SOC and utils.JK_BMS_AUTO_RESET_SOC:
+            self.jk.JK_BMS_OVPR_TRIGGER_RESET = utils.JK_BMS_OVPR_TRIGGER_RESET
+            self.jk.JK_BMS_OVP_TRIGGER_RESET = utils.JK_BMS_OVP_TRIGGER_RESET
+            self.jk.JK_BMS_OVP_DEFAULT = utils.JK_BMS_OVP_DEFAULT
+            self.jk.JK_BMS_OVPR_DEFAULT = utils.JK_BMS_OVPR_DEFAULT
             if self.last_soc_reset_time is None:
                 self.jk.trigger_soc_reset = True
                 self.last_soc_reset_time = int(time())

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -86,6 +86,12 @@ class Jkbms_Ble(Battery):
         self.max_battery_voltage = st["cell_ovp"] * self.cell_count
         self.min_battery_voltage = st["cell_uvp"] * self.cell_count
 
+        # Persist initial OVP and OPVR settings of JK BMS BLE
+        if self.jk.ovp_initial_voltage is None or self.jk.ovpr_initial_voltage is None:
+            self.jk.ovp_initial_voltage = st["cell_ovp"]
+            self.jk.ovpr_initial_voltage = st["cell_ovpr"]
+            logger.error("Persisting OVP: " + str(self.jk.ovp_initial_voltage) + " and OVPR: " + str(self.jk.ovpr_initial_voltage))
+
         # "User Private Data" field in APP
         tmp = self.jk.get_status()["device_info"]["production"]
         self.custom_field = tmp if tmp != "Input Us" else None
@@ -257,6 +263,6 @@ class Jkbms_Ble(Battery):
 
     def trigger_soc_reset(self):
         if utils.AUTO_RESET_SOC:
-            self.jk.get_status()
+            self.jk.max_cell_voltage = self.get_max_cell_voltage()
             self.jk.trigger_soc_reset = True
         return

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -21,7 +21,6 @@ class Jkbms_Ble(Battery):
         self.type = self.BATTERYTYPE
         self.jk = Jkbms_Brn(address)
         self.unique_identifier_tmp = ""
-        self.last_soc_reset_time = None
 
         logger.info("Init of Jkbms_Ble at " + address)
 
@@ -257,21 +256,7 @@ class Jkbms_Ble(Battery):
         return 1 if self.balancing else 0
 
     def trigger_soc_reset(self):
-        if utils.AUTO_RESET_SOC and utils.JK_BMS_AUTO_RESET_SOC:
-            self.jk.JK_BMS_OVPR_TRIGGER_RESET = utils.JK_BMS_OVPR_TRIGGER_RESET
-            self.jk.JK_BMS_OVP_TRIGGER_RESET = utils.JK_BMS_OVP_TRIGGER_RESET
-            self.jk.JK_BMS_OVP_DEFAULT = utils.JK_BMS_OVP_DEFAULT
-            self.jk.JK_BMS_OVPR_DEFAULT = utils.JK_BMS_OVPR_DEFAULT
-            if self.last_soc_reset_time is None:
-                self.jk.trigger_soc_reset = True
-                self.last_soc_reset_time = int(time())
-                logger.debug("Triggering SOC reset BLE")
-            else:
-                tdiff = int(time()) - self.last_soc_reset_time
-                if utils.JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET < tdiff:
-                    self.jk.trigger_soc_reset = True
-                    self.last_soc_reset_time = int(time())
-                    logger.debug("Triggering SOC reset BLE")
-                else:
-                    logger.debug("Waiting for timeout ... " + str(tdiff))
+        if utils.AUTO_RESET_SOC:
+            self.jk.get_status()
+            self.jk.trigger_soc_reset = True
         return

--- a/etc/dbus-serialbattery/bms/jkbms_brn.py
+++ b/etc/dbus-serialbattery/bms/jkbms_brn.py
@@ -98,6 +98,10 @@ class Jkbms_Brn:
         self.address = addr
         self.bt_thread = threading.Thread(target=self.connect_and_scrape)
         self.trigger_soc_reset = False
+        self.JK_BMS_OVPR_TRIGGER_RESET = 0
+        self.JK_BMS_OVP_TRIGGER_RESET = 0
+        self.JK_BMS_OVP_DEFAULT = 0
+        self.JK_BMS_OVPR_DEFAULT = 0
 
     async def scanForDevices(self):
         devices = await BleakScanner.discover()
@@ -364,8 +368,8 @@ class Jkbms_Brn:
                 # last_dev_info = time()
                 while client.is_connected and self.run and self.main_thread.is_alive():
                     if self.trigger_soc_reset:
-                        await self.reset_soc_jk(client)
                         self.trigger_soc_reset = False
+                        await self.reset_soc_jk(client)
                     await asyncio.sleep(0.01)
             except Exception as err:
                 self.run = False
@@ -427,15 +431,15 @@ class Jkbms_Brn:
     async def reset_soc_jk(self, c):
         # Lowering OVPR / OVP
         # That will trigger a High Voltage Alert
-        await self.write_register(JK_REGISTER_OVPR, self.jk_float_to_hex_little(utils.JK_BMS_OVPR_TRIGGER_RESET), 0x04, c, True)
-        await self.write_register(JK_REGISTER_OVP, self.jk_float_to_hex_little(utils.JK_BMS_OVP_TRIGGER_RESET), 0x04, c, True)
+        await self.write_register(JK_REGISTER_OVPR, self.jk_float_to_hex_little(self.JK_BMS_OVPR_TRIGGER_RESET), 0x04, c, True)
+        await self.write_register(JK_REGISTER_OVP, self.jk_float_to_hex_little(self.JK_BMS_OVP_TRIGGER_RESET), 0x04, c, True)
 
         # Give BMS some time to recognize
         await asyncio.sleep(10)
 
         # Set values back to default
-        await self.write_register(JK_REGISTER_OVP, self.jk_float_to_hex_little(utils.JK_BMS_OVP_DEFAULT), 0X04, c, True)
-        await self.write_register(JK_REGISTER_OVPR, self.jk_float_to_hex_little(utils.JK_BMS_OVPR_DEFAULT), 0x04, c, True)
+        await self.write_register(JK_REGISTER_OVP, self.jk_float_to_hex_little(self.JK_BMS_OVP_DEFAULT), 0X04, c, True)
+        await self.write_register(JK_REGISTER_OVPR, self.jk_float_to_hex_little(self.JK_BMS_OVPR_DEFAULT), 0x04, c, True)
 
 if __name__ == "__main__":
     import sys

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -208,15 +208,6 @@ CUSTOM_BATTERY_NAMES =
 ; If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
 ; Currently only working for Daly and JK BMS
 AUTO_RESET_SOC = True
-; --------- JK BMS specific settings for SOC reset ---------
-; WARNING! Beta code only tested with HW 11!
-; WARNING! This will always set your JK BMS OVP and OVPR values to this settings!
-JK_BMS_AUTO_RESET_SOC = False
-JK_BMS_OVPR_DEFAULT = 3.450
-JK_BMS_OVP_DEFAULT = 3.550
-JK_BMS_OVPR_TRIGGER_RESET = 3.300
-JK_BMS_OVP_TRIGGER_RESET = 3.400
-JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET = 3600
 
 ; Publish the config settings to the dbus path "/Info/Config/"
 PUBLISH_CONFIG_VALUES = 1

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -221,7 +221,7 @@ CUSTOM_BATTERY_NAMES =
 
 ; Auto reset SoC
 ; If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
-; Currently only working for Daly and JK BMS
+; Currently only working for Daly and JK BMS BLE
 AUTO_RESET_SOC = True
 
 ; Publish the config settings to the dbus path "/Info/Config/"

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -202,8 +202,17 @@ CUSTOM_BATTERY_NAMES =
 
 ; Auto reset SoC
 ; If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
-; Currently only working for Daly BMS
+; Currently only working for Daly and JK BMS
 AUTO_RESET_SOC = True
+; --------- JK BMS specific settings for SOC reset ---------
+; WARNING! Beta code only tested with HW 11!
+; WARNING! This will always set your JK BMS OVP and OVPR values to this settings!
+JK_BMS_AUTO_RESET_SOC = False
+JK_BMS_OVPR_DEFAULT = 3.450
+JK_BMS_OVP_DEFAULT = 3.550
+JK_BMS_OVPR_TRIGGER_RESET = 3.300
+JK_BMS_OVP_TRIGGER_RESET = 3.400
+JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET = 3600
 
 ; Publish the config settings to the dbus path "/Info/Config/"
 PUBLISH_CONFIG_VALUES = 1

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -221,7 +221,7 @@ CUSTOM_BATTERY_NAMES =
 
 ; Auto reset SoC
 ; If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
-; Currently only working for Daly and JK BMS BLE
+; Currently only working for Daly BMS and JK BMS BLE
 AUTO_RESET_SOC = True
 
 ; Publish the config settings to the dbus path "/Info/Config/"

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -300,8 +300,27 @@ CUSTOM_BATTERY_NAMES = _get_list_from_config(
 
 # Auto reset SoC
 # If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
-# Currently only working for Daly BMS
+# Currently only working for Daly and JK BMS
 AUTO_RESET_SOC = "True" == config["DEFAULT"]["AUTO_RESET_SOC"]
+# --------- JK BMS specific settings for SOC reset ---------
+# WARNING! Beta code only tested with HW 11!
+# WARNING! This will always set your JK BMS OVP and OVPR values to this settings!
+JK_BMS_AUTO_RESET_SOC = "True" == config["DEFAULT"]["JK_BMS_AUTO_RESET_SOC"]
+JK_BMS_OVPR_DEFAULT  = float(config["DEFAULT"]["JK_BMS_OVPR_DEFAULT"])
+JK_BMS_OVP_DEFAULT = float(config["DEFAULT"]["JK_BMS_OVP_DEFAULT"])
+if JK_BMS_OVP_DEFAULT < JK_BMS_OVPR_DEFAULT:
+    logger.error(
+        ">>> ERROR: JK_BMS_OVPR_DEFAULT is set to a value greater than JK_BMS_OVP_DEFAULT. " +
+        "Please check the configuration."
+    )
+JK_BMS_OVPR_TRIGGER_RESET = float(config["DEFAULT"]["JK_BMS_OVPR_TRIGGER_RESET"])
+JK_BMS_OVP_TRIGGER_RESET = float(config["DEFAULT"]["JK_BMS_OVP_TRIGGER_RESET"])
+if JK_BMS_OVP_TRIGGER_RESET < JK_BMS_OVPR_TRIGGER_RESET:
+    logger.error(
+        ">>> ERROR: JK_BMS_OVPR_TRIGGER_RESET is set to a value greater than JK_BMS_OVP_TRIGGER_RESET. " +
+        "Please check the configuration."
+    )
+JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET = int(config["DEFAULT"]["JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET"])
 
 # Publish the config settings to the dbus path "/Info/Config/"
 PUBLISH_CONFIG_VALUES = int(config["DEFAULT"]["PUBLISH_CONFIG_VALUES"])

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -306,25 +306,6 @@ CUSTOM_BATTERY_NAMES = _get_list_from_config(
 # If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
 # Currently only working for Daly and JK BMS
 AUTO_RESET_SOC = "True" == config["DEFAULT"]["AUTO_RESET_SOC"]
-# --------- JK BMS specific settings for SOC reset ---------
-# WARNING! Beta code only tested with HW 11!
-# WARNING! This will always set your JK BMS OVP and OVPR values to this settings!
-JK_BMS_AUTO_RESET_SOC = "True" == config["DEFAULT"]["JK_BMS_AUTO_RESET_SOC"]
-JK_BMS_OVPR_DEFAULT  = float(config["DEFAULT"]["JK_BMS_OVPR_DEFAULT"])
-JK_BMS_OVP_DEFAULT = float(config["DEFAULT"]["JK_BMS_OVP_DEFAULT"])
-if JK_BMS_OVP_DEFAULT < JK_BMS_OVPR_DEFAULT:
-    logger.error(
-        ">>> ERROR: JK_BMS_OVPR_DEFAULT is set to a value greater than JK_BMS_OVP_DEFAULT. " +
-        "Please check the configuration."
-    )
-JK_BMS_OVPR_TRIGGER_RESET = float(config["DEFAULT"]["JK_BMS_OVPR_TRIGGER_RESET"])
-JK_BMS_OVP_TRIGGER_RESET = float(config["DEFAULT"]["JK_BMS_OVP_TRIGGER_RESET"])
-if JK_BMS_OVP_TRIGGER_RESET < JK_BMS_OVPR_TRIGGER_RESET:
-    logger.error(
-        ">>> ERROR: JK_BMS_OVPR_TRIGGER_RESET is set to a value greater than JK_BMS_OVP_TRIGGER_RESET. " +
-        "Please check the configuration."
-    )
-JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET = int(config["DEFAULT"]["JK_BMS_WAIT_UNTIL_NEXT_SOC_RESET"])
 
 # Publish the config settings to the dbus path "/Info/Config/"
 PUBLISH_CONFIG_VALUES = int(config["DEFAULT"]["PUBLISH_CONFIG_VALUES"])

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -212,7 +212,7 @@ CUSTOM_BATTERY_NAMES = _get_list_from_config(
 
 # Auto reset SoC
 # If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
-# Currently only working for Daly and JK BMS
+# Currently only working for Daly and JK BMS BLE
 AUTO_RESET_SOC = "True" == config["DEFAULT"]["AUTO_RESET_SOC"]
 
 PUBLISH_CONFIG_VALUES = int(config["DEFAULT"]["PUBLISH_CONFIG_VALUES"])

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -212,7 +212,7 @@ CUSTOM_BATTERY_NAMES = _get_list_from_config(
 
 # Auto reset SoC
 # If on, then SoC is reset to 100%, if the value switches from absorption to float voltage
-# Currently only working for Daly and JK BMS BLE
+# Currently only working for Daly BMS and JK BMS BLE
 AUTO_RESET_SOC = "True" == config["DEFAULT"]["AUTO_RESET_SOC"]
 
 PUBLISH_CONFIG_VALUES = int(config["DEFAULT"]["PUBLISH_CONFIG_VALUES"])


### PR DESCRIPTION
This will add a feature to automatically reset SOC of JK BMS based on the `manage_charge_voltage` calculations.

**Warning:** This will modify `OVP` and `OVPR` settings of your BMS when enabled. **Use it at your own risk!**

The feature is disabled by default. `AUTO_RESET_SOC` and `JK_BMS_AUTO_RESET_SOC` have to be enabled in your config to make it work.

Probably fixes #703 