### PR TITLE
Changes 2023.07.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added: Load to bulk voltage every x days to reset the SoC to 100% for some BMS by @mr-manuel
 * Added: Save custom name and make it restart persistant by @mr-manuel
 * Added: Temperature names to dbus and mqtt by @mr-manuel
+* Added: Use current average of the last 300 cycles for time to go and time to SoC calculation by @mr-manuel
 * Added: Validate current, voltage, capacity and SoC for all BMS. This prevents that a device, which is no BMS, is detected as BMS. Fixes also https://github.com/Louisvdw/dbus-serialbattery/issues/479 by @mr-manuel
 * Changed: Enable BMS that are disabled by default by specifying it in the config file. No more need to edit scripts by @mr-manuel
 * Changed: Fix daly readsentence by @transistorgit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added: JKBMS BLE - Show last five characters from the MAC address in the custom name (which is displayed in the device list) by @mr-manuel
 * Added: Load to bulk voltage every x days to reset the SoC to 100% for some BMS by @mr-manuel
 * Added: Save custom name and make it restart persistant by @mr-manuel
+* Added: Temperature names to dbus and mqtt by @mr-manuel
 * Added: Validate current, voltage, capacity and SoC for all BMS. This prevents that a device, which is no BMS, is detected as BMS. Fixes also https://github.com/Louisvdw/dbus-serialbattery/issues/479 by @mr-manuel
 * Changed: Enable BMS that are disabled by default by specifying it in the config file. No more need to edit scripts by @mr-manuel
 * Changed: Fix daly readsentence by @transistorgit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added: Temperature names to dbus and mqtt by @mr-manuel
 * Added: Use current average of the last 300 cycles for time to go and time to SoC calculation by @mr-manuel
 * Added: Validate current, voltage, capacity and SoC for all BMS. This prevents that a device, which is no BMS, is detected as BMS. Fixes also https://github.com/Louisvdw/dbus-serialbattery/issues/479 by @mr-manuel
+* Changed: Calculate only positive Time-to-SoC points by @mr-manuel
 * Changed: Enable BMS that are disabled by default by specifying it in the config file. No more need to edit scripts by @mr-manuel
 * Changed: Fix daly readsentence by @transistorgit
 * Changed: Fix Sinowealth not loading https://github.com/Louisvdw/dbus-serialbattery/issues/702 by @mr-manuel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.x
 * Added: Bluetooth: Show signal strength of BMS in log by @mr-manuel
 * Added: Create unique identifier, if not provided from BMS by @mr-manuel
+* Added: Current average of the last 5 minutes by @mr-manuel
 * Added: Daly BMS: Auto reset SoC when changing to float (can be turned off in the config file) by @transistorgit
 * Added: Exclude a device from beeing used by the dbus-serialbattery driver by @mr-manuel
 * Added: Implement callback function for update by @seidler2547
@@ -12,7 +13,6 @@
 * Added: Temperature names to dbus and mqtt by @mr-manuel
 * Added: Use current average of the last 300 cycles for time to go and time to SoC calculation by @mr-manuel
 * Added: Validate current, voltage, capacity and SoC for all BMS. This prevents that a device, which is no BMS, is detected as BMS. Fixes also https://github.com/Louisvdw/dbus-serialbattery/issues/479 by @mr-manuel
-* Changed: Calculate only positive Time-to-SoC points by @mr-manuel
 * Changed: Enable BMS that are disabled by default by specifying it in the config file. No more need to edit scripts by @mr-manuel
 * Changed: Fix daly readsentence by @transistorgit
 * Changed: Fix Sinowealth not loading https://github.com/Louisvdw/dbus-serialbattery/issues/702 by @mr-manuel
@@ -25,6 +25,8 @@
 * Changed: Improved driver reinstall when multiple Bluetooth BMS are enabled by @mr-manuel
 * Changed: Improved Jkbms_Ble driver by @seidler2547 & @mr-manuel
 * Changed: Reduce the big inrush current if the CVL jumps from Bulk/Absorbtion to Float https://github.com/Louisvdw/dbus-serialbattery/issues/659 by @Rikkert-RS & @ogurevich
+* Changed: Time-to-Go and Time-to-SoC use the current average of the last 5 minutes for calculation by @mr-manuel
+* Changed: Time-to-SoC calculate only positive points by @mr-manuel
 * Removed: Cronjob to restart Bluetooth service every 12 hours by @mr-manuel
 
 

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -260,10 +260,12 @@ class Battery(ABC):
                 or utils.BULK_AFTER_DAYS < bulk_last_reached_days_ago
             )
         ):
+            """
             logger.info(
                 f"set bulk_requested to True: first time (0) or {utils.BULK_AFTER_DAYS}"
                 + f" < {round(bulk_last_reached_days_ago, 2)}"
             )
+            """
             self.bulk_requested = True
 
         self.bulk_battery_voltage = round(utils.BULK_CELL_VOLTAGE * self.cell_count, 2)
@@ -396,7 +398,7 @@ class Battery(ABC):
                 chargeMode = "Float"
                 # reset bulk when going into float
                 if self.bulk_requested:
-                    logger.info("set bulk_requested to False")
+                    # logger.info("set bulk_requested to False")
                     self.bulk_requested = False
                     # IDEA: Save "bulk_last_reached" in the dbus path com.victronenergy.settings
                     # to make it restart persistent
@@ -436,7 +438,7 @@ class Battery(ABC):
             self.charge_mode += " (Linear Mode)"
 
             # uncomment for enabling debugging infos in GUI
-            # """
+            """
             self.charge_mode_debug = (
                 f"max_battery_voltage: {round(self.max_battery_voltage, 2)}V"
             )
@@ -550,7 +552,7 @@ class Battery(ABC):
                 self.charge_mode = "Float"
                 # reset bulk when going into float
                 if self.bulk_requested:
-                    logger.info("set bulk_requested to False")
+                    # logger.info("set bulk_requested to False")
                     self.bulk_requested = False
                     self.bulk_last_reached = current_time
 

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -83,6 +83,8 @@ class Battery(ABC):
         """
         self.voltage = None
         self.current = None
+        self.current_avg = None
+        self.current_avg_lst = []
         self.capacity_remain = None
         self.capacity = None
         self.cycles = None

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -881,6 +881,14 @@ class Battery(ABC):
         else:
             diffSoc = self.soc - socnum
 
+        """
+        calculate only positive SoC points, since negative points have no sense
+        when charging only points above current SoC are shown
+        when discharging only points below current SoC are shown
+        """
+        if diffSoc < 0:
+            return None
+
         ttgStr = None
         if self.soc != socnum and (diffSoc > 0 or utils.TIME_TO_SOC_INC_FROM is True):
             secondstogo = int(diffSoc / crntPrctPerSec)

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -210,9 +210,13 @@ class DbusHelper:
         self._dbusservice.add_path("/System/MaxTemperatureCellId", None, writeable=True)
         self._dbusservice.add_path("/System/MOSTemperature", None, writeable=True)
         self._dbusservice.add_path("/System/Temperature1", None, writeable=True)
+        self._dbusservice.add_path("/System/Temperature1Name", None, writeable=True)
         self._dbusservice.add_path("/System/Temperature2", None, writeable=True)
+        self._dbusservice.add_path("/System/Temperature2Name", None, writeable=True)
         self._dbusservice.add_path("/System/Temperature3", None, writeable=True)
+        self._dbusservice.add_path("/System/Temperature3Name", None, writeable=True)
         self._dbusservice.add_path("/System/Temperature4", None, writeable=True)
+        self._dbusservice.add_path("/System/Temperature4Name", None, writeable=True)
         self._dbusservice.add_path(
             "/System/MaxCellVoltage",
             None,
@@ -463,9 +467,13 @@ class DbusHelper:
         ] = self.battery.get_max_temp_id()
         self._dbusservice["/System/MOSTemperature"] = self.battery.get_mos_temp()
         self._dbusservice["/System/Temperature1"] = self.battery.temp1
+        self._dbusservice["/System/Temperature1Name"] = utils.TEMP_1_NAME
         self._dbusservice["/System/Temperature2"] = self.battery.temp2
+        self._dbusservice["/System/Temperature2Name"] = utils.TEMP_2_NAME
         self._dbusservice["/System/Temperature3"] = self.battery.temp3
+        self._dbusservice["/System/Temperature3Name"] = utils.TEMP_3_NAME
         self._dbusservice["/System/Temperature4"] = self.battery.temp4
+        self._dbusservice["/System/Temperature4Name"] = utils.TEMP_4_NAME
 
         # Voltage control
         self._dbusservice["/Info/MaxChargeVoltage"] = self.battery.control_voltage

--- a/etc/dbus-serialbattery/qml/PageBattery.qml
+++ b/etc/dbus-serialbattery/qml/PageBattery.qml
@@ -95,6 +95,12 @@ MbPage {
         }
 
         MbItemValue {
+            description: qsTr("Current (last 5 minutes avg.)")
+            item.bind: service.path("/CurrentAvg")
+            show: item.seen
+        }
+
+        MbItemValue {
             id: soc
 
             description: qsTr("State of charge")

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -38,7 +38,7 @@ def _get_list_from_config(
 
 
 # Constants - Need to dynamically get them in future
-DRIVER_VERSION = "1.0.20230711dev"
+DRIVER_VERSION = "1.0.20230717dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -38,7 +38,7 @@ def _get_list_from_config(
 
 
 # Constants - Need to dynamically get them in future
-DRIVER_VERSION = "1.0.20230717dev"
+DRIVER_VERSION = "1.0.20230723dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 


### PR DESCRIPTION
* Added: Current average of the last 5 minutes by @mr-manuel
* Added: Temperature names to dbus and mqtt by @mr-manuel
* Added: Use current average of the last 300 cycles for time to go and time to SoC calculation by @mr-manuel
* Changed: Time-to-Go and Time-to-SoC use the current average of the last 5 minutes for calculation by @mr-manuel
* Changed: Time-to-SoC calculate only positive points by @mr-manuel