### PR TITLE
add battery current filtering for Daly BMS

### DIFF
--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -230,7 +230,7 @@ class Daly(Battery):
             )
             if crntMinValid < current < crntMaxValid:
                 self.voltage = voltage / 10
-                
+
                 if self.current is None or utils.AVERAGE_CURRENT_TIME_CONSTANT == 0:
                     self.current = current
                 else:
@@ -240,7 +240,7 @@ class Daly(Battery):
                     w = 2 * math.pi * dT / utils.AVERAGE_CURRENT_TIME_CONSTANT
                     a = w / (w + 1)
                     self.current = (1 - a) * self.current + a * current
-                
+
                 self.soc = soc / 10
                 return True
 

--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -6,6 +6,7 @@ from struct import unpack_from, pack_into
 from time import sleep, time
 from datetime import datetime
 from re import sub
+import math
 
 
 class Daly(Battery):
@@ -229,7 +230,17 @@ class Daly(Battery):
             )
             if crntMinValid < current < crntMaxValid:
                 self.voltage = voltage / 10
-                self.current = current
+                
+                if self.current is None or utils.AVERAGE_CURRENT_TIME_CONSTANT == 0:
+                    self.current = current
+                else:
+                    # time between two sampling points
+                    dT = 0.5
+                    # first order low pass filter
+                    w = 2 * math.pi * dT / utils.AVERAGE_CURRENT_TIME_CONSTANT
+                    a = w / (w + 1)
+                    self.current = (1 - a) * self.current + a * current
+                
                 self.soc = soc / 10
                 return True
 

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -240,6 +240,8 @@ SOC_LOW_ALARM   = 10
 BATTERY_CAPACITY = 50
 ; Invert Battery Current. Default non-inverted. Set to -1 to invert
 INVERT_CURRENT_MEASUREMENT = 1
+; Average battery current over time. Set filter time constant in seconds. Set to 0 to disable.
+AVERAGE_CURRENT_TIME_CONSTANT = 10
 
 ; -- ESC GreenMeter and Lipro device settings
 GREENMETER_ADDRESS  = 1

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -319,7 +319,9 @@ BATTERY_CAPACITY = float(config["DEFAULT"]["BATTERY_CAPACITY"])
 # Invert Battery Current. Default non-inverted. Set to -1 to invert
 INVERT_CURRENT_MEASUREMENT = int(config["DEFAULT"]["INVERT_CURRENT_MEASUREMENT"])
 # Average battery current. Set filter time constant in seconds. Set to 0 to disable.
-AVERAGE_CURRENT_TIME_CONSTANT = float(config["DEFAULT"]["AVERAGE_CURRENT_TIME_CONSTANT"])
+AVERAGE_CURRENT_TIME_CONSTANT = float(
+    config["DEFAULT"]["AVERAGE_CURRENT_TIME_CONSTANT"]
+)
 
 # -- ESC GreenMeter and Lipro device settings
 GREENMETER_ADDRESS = int(config["DEFAULT"]["GREENMETER_ADDRESS"])

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -318,6 +318,8 @@ SOC_LOW_ALARM = float(config["DEFAULT"]["SOC_LOW_ALARM"])
 BATTERY_CAPACITY = float(config["DEFAULT"]["BATTERY_CAPACITY"])
 # Invert Battery Current. Default non-inverted. Set to -1 to invert
 INVERT_CURRENT_MEASUREMENT = int(config["DEFAULT"]["INVERT_CURRENT_MEASUREMENT"])
+# Average battery current. Set filter time constant in seconds. Set to 0 to disable.
+AVERAGE_CURRENT_TIME_CONSTANT = float(config["DEFAULT"]["AVERAGE_CURRENT_TIME_CONSTANT"])
 
 # -- ESC GreenMeter and Lipro device settings
 GREENMETER_ADDRESS = int(config["DEFAULT"]["GREENMETER_ADDRESS"])


### PR DESCRIPTION
As mentioned in #739, Daly BMS struggle at current measurements. I had the same problem and it seems that the BMS samples random values within the current waveform. This fork implements a configurable first order low pass filter to get stable current values. 

I am not sure, how common this problem is. Currently, this fork enables filtering by default.