### PR TITLE
bugfix: Type conversion NoneType to Int

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -877,7 +877,9 @@ class Battery(ABC):
             return self.capacity * self.soc / 100
         return None
 
-    def get_timeToSoc(self, socnum, crntPrctPerSec, onlyNumber=False) -> str:
+    def get_timeToSoc(
+        self, socnum, crntPrctPerSec, onlyNumber=False
+    ) -> Union[str, None]:
         if self.current > 0:
             diffSoc = socnum - self.soc
         else:

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -636,25 +636,22 @@ class DbusHelper:
 
                 # Update TimeToGo item
                 if utils.TIME_TO_GO_ENABLE:
-                    if self.battery.current_avg is not None:
-                        # Update TimeToGo item, has to be a positive int since it's used from dbus-systemcalc-py
-                        self._dbusservice["/TimeToGo"] = (
-                            abs(
-                                int(
-                                    self.battery.get_timeToSoc(
-                                        # switch value depending on charging/discharging
-                                        utils.SOC_LOW_WARNING
-                                        if self.battery.current_avg < 0
-                                        else 100,
-                                        crntPrctPerSec,
-                                        True,
-                                    )
-                                )
-                            )
-                            if self.battery.current_avg
-                            and abs(self.battery.current_avg) > 0.1
-                            else None
+                    if (
+                        self.battery.current_avg is not None
+                        and abs(self.battery.current_avg) > 0.1
+                    ):
+                        time_to_go = self.battery.get_timeToSoc(
+                            # switch value depending on charging/discharging
+                            utils.SOC_LOW_WARNING
+                            if self.battery.current_avg < 0
+                            else 100,
+                            crntPrctPerSec,
+                            True,
                         )
+                        # Update TimeToGo item, has to be a positive int since it's used from dbus-systemcalc-py
+                        if time_to_go is not None and not isinstance(time_to_go, int):
+                            time_to_go = abs(int(time_to_go))
+                        self._dbusservice["/TimeToGo"] = time_to_go
                     else:
                         self._dbusservice["/TimeToGo"] = None
 


### PR DESCRIPTION
TypeError("int() argument must be a string, a bytes-like object or a number, not 'NoneType'") of type <class 'TypeError'> in /opt/victronenergy/dbus-serialbattery/dbushelper.py line #643
