### PR TITLE
Changes 2023.09.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Changed: Improved battery voltage handling in linear absorption mode by @ogurevich
 * Changed: Improved driver disable script by @md-manuel
 * Changed: Improved driver reinstall when multiple Bluetooth BMS are enabled by @mr-manuel
+* Changed: JKBMS - Driver do not start if manufacturer date in BMS is empty https://github.com/Louisvdw/dbus-serialbattery/issues/823 by @mr-manuel
 * Changed: JKBMS_BLE BMS - Improved driver by @seidler2547 & @mr-manuel
 * Changed: LLT/JBD BMS - Fix cycle capacity with https://github.com/Louisvdw/dbus-serialbattery/pull/762 by @idstein
 * Changed: LLT/JBD BMS - Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/730 by @mr-manuel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v1.0.x
+
 * Added: Bluetooth: Show signal strength of BMS in log by @mr-manuel
 * Added: Create unique identifier, if not provided from BMS by @mr-manuel
 * Added: Current average of the last 5 minutes by @mr-manuel
@@ -18,6 +19,7 @@
 * Added: Temperature names to dbus and mqtt by @mr-manuel
 * Added: Use current average of the last 300 cycles for time to go and time to SoC calculation by @mr-manuel
 * Added: Validate current, voltage, capacity and SoC for all BMS. This prevents that a device, which is no BMS, is detected as BMS. Fixes also https://github.com/Louisvdw/dbus-serialbattery/issues/479 by @mr-manuel
+* Changed: `VOLTAGE_DROP` now behaves differently. Before it reduced the voltage for the check, now the voltage for the charger is increased in order to get the target voltage on the BMS by @mr-manuel
 * Changed: Daly BMS - Fix readsentence by @transistorgit
 * Changed: Enable BMS that are disabled by default by specifying it in the config file. No more need to edit scripts by @mr-manuel
 * Changed: Fixed Building wheel for dbus-fast won't finish on weak systems https://github.com/Louisvdw/dbus-serialbattery/issues/785 by @mr-manuel
@@ -31,8 +33,10 @@
 * Changed: Improved driver reinstall when multiple Bluetooth BMS are enabled by @mr-manuel
 * Changed: JKBMS_BLE BMS - Improved driver by @seidler2547 & @mr-manuel
 * Changed: LLT/JBD BMS - Fix cycle capacity with https://github.com/Louisvdw/dbus-serialbattery/pull/762 by @idstein
+* Changed: LLT/JBD BMS - Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/730 by @mr-manuel
+* Changed: LLT/JBD BMS - Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/769 by @mr-manuel
 * Changed: LLT/JBD BMS - Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/778 with https://github.com/Louisvdw/dbus-serialbattery/pull/798 by @idstein
-* Changed: LLT/JBD BMS - Improved error handling and automatical driver restart in case of error. Should fix https://github.com/Louisvdw/dbus-serialbattery/issues/730, https://github.com/Louisvdw/dbus-serialbattery/issues/769 and https://github.com/Louisvdw/dbus-serialbattery/issues/777 by @mr-manuel
+* Changed: LLT/JBD BMS - Improved error handling and automatical driver restart in case of error. Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/777 by @mr-manuel
 * Changed: LLT/JBD BMS - SOC different in Xiaoxiang app and dbus-serialbattery with https://github.com/Louisvdw/dbus-serialbattery/pull/760 by @idstein
 * Changed: Make CCL and DCL limiting messages more clear by @mr-manuel
 * Changed: Reduce the big inrush current if the CVL jumps from Bulk/Absorbtion to Float https://github.com/Louisvdw/dbus-serialbattery/issues/659 by @Rikkert-RS & @ogurevich
@@ -44,7 +48,7 @@
 
 ## v1.0.20230531
 
-### ATTENTION: Breaking changes! The config is now done in the `config.ini`. All values from the `utils.py` gets lost. The changes in the `config.ini` will persists future updates.
+### ATTENTION: Breaking changes! The config is now done in the `config.ini`. All values from the `utils.py` get lost. The changes in the `config.ini` will persists future updates.
 
 * Added: `self.unique_identifier` to the battery class. Used to identify a BMS when multiple BMS are connected - planned for future use by @mr-manuel
 * Added: Alert is triggered, when BMS communication is lost by @mr-manuel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Breaking changes
+
+* Driver version greater or equal to `v1.0.20230629beta` and smaller or equal to `v1.0.20230926beta`:
+
+  With `v1.0.20230927beta` the following values changed names:
+  * `BULK_CELL_VOLTAGE` -> `SOC_RESET_VOLTAGE`
+  * `BULK_AFTER_DAYS` -> `SOC_RESET_AFTER_DAYS`
+
 ## v1.0.x
 
 * Added: Bluetooth: Show signal strength of BMS in log by @mr-manuel
@@ -14,7 +22,7 @@
 * Added: JKBMS BMS connect via CAN (experimental, some limits apply) by @IrisCrimson and @mr-manuel
 * Added: LLT/JBD BMS - Discharge / Charge Mosfet and disable / enable balancer switching over remote console/GUI with https://github.com/Louisvdw/dbus-serialbattery/pull/761 by @idstein
 * Added: LLT/JBD BMS - Show balancer state in GUI under the IO page with https://github.com/Louisvdw/dbus-serialbattery/pull/763 by @idstein
-* Added: Load to bulk voltage every x days to reset the SoC to 100% for some BMS by @mr-manuel
+* Added: Load to SOC reset voltage every x days to reset the SoC to 100% for some BMS by @mr-manuel
 * Added: Save custom name and make it restart persistant by @mr-manuel
 * Added: Temperature names to dbus and mqtt by @mr-manuel
 * Added: Use current average of the last 300 cycles for time to go and time to SoC calculation by @mr-manuel

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -321,7 +321,7 @@ class Battery(ABC):
             if self.max_voltage_start_time is None:
                 # start timer, if max voltage is reached and cells are balanced
                 if (
-                    self.max_battery_voltage - utils.VOLTAGE_DROP <= voltageSum
+                    self.max_battery_voltage <= voltageSum
                     and voltageDiff <= utils.CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL
                     and self.allow_max_voltage
                 ):
@@ -355,9 +355,7 @@ class Battery(ABC):
                 # regardless of whether we were in absorption mode or not
                 if (
                     voltageSum
-                    < self.max_battery_voltage
-                    - utils.VOLTAGE_DROP
-                    - measurementToleranceVariation
+                    < self.max_battery_voltage - measurementToleranceVariation
                 ):
                     self.max_voltage_start_time = None
 
@@ -515,10 +513,7 @@ class Battery(ABC):
 
             if self.max_voltage_start_time is None:
                 # check if max voltage is reached and start timer to keep max voltage
-                if (
-                    self.max_battery_voltage - utils.VOLTAGE_DROP <= voltageSum
-                    and self.allow_max_voltage
-                ):
+                if self.max_battery_voltage <= voltageSum and self.allow_max_voltage:
                     # example 2
                     self.max_voltage_start_time = current_time
 

--- a/etc/dbus-serialbattery/bms/jkbms.py
+++ b/etc/dbus-serialbattery/bms/jkbms.py
@@ -175,11 +175,14 @@ class Jkbms(Battery):
         self.custom_field = tmp if tmp != "Input Us" else None
 
         # production date
-        offset = cellbyte_count + 164
-        tmp = unpack_from(">4s", self.get_data(status_data, b"\xB5", offset, 4))[
-            0
-        ].decode()
-        self.production = "20" + tmp + "01" if tmp and tmp != "" else None
+        try:
+            offset = cellbyte_count + 164
+            tmp = unpack_from(">4s", self.get_data(status_data, b"\xB5", offset, 4))[
+                0
+            ].decode()
+            self.production = "20" + tmp + "01" if tmp and tmp != "" else None
+        except UnicodeEncodeError:
+            self.production = None
 
         offset = cellbyte_count + 174
         self.version = unpack_from(

--- a/etc/dbus-serialbattery/bms/jkbms.py
+++ b/etc/dbus-serialbattery/bms/jkbms.py
@@ -284,8 +284,8 @@ class Jkbms(Battery):
         # MOSFET temperature alarm
         self.protection.temp_high_internal = 2 if is_bit_set(tmp[pos - 1]) else 0
         # charge over voltage alarm
-        # TODO: check if "self.bulk_requested is False" works,
-        # else use "self.bulk_last_reached < int(time()) - (60 * 60)"
+        # TODO: check if "self.soc_reset_requested is False" works,
+        # else use "self.soc_reset_last_reached < int(time()) - (60 * 60)"
         self.protection.voltage_high = 2 if is_bit_set(tmp[pos - 2]) else 0
         # discharge under voltage alarm
         self.protection.voltage_low = 2 if is_bit_set(tmp[pos - 3]) else 0

--- a/etc/dbus-serialbattery/bms/jkbms.py
+++ b/etc/dbus-serialbattery/bms/jkbms.py
@@ -181,7 +181,7 @@ class Jkbms(Battery):
                 0
             ].decode()
             self.production = "20" + tmp + "01" if tmp and tmp != "" else None
-        except UnicodeEncodeError:
+        except UnicodeDecodeError:
             self.production = None
 
         offset = cellbyte_count + 174

--- a/etc/dbus-serialbattery/bms/jkbms_brn.py
+++ b/etc/dbus-serialbattery/bms/jkbms_brn.py
@@ -200,6 +200,8 @@ class Jkbms_Brn:
         for t in TRANSLATE_CELL_INFO:
             self.translate(fb, t, self.bms_status, f32s=has32s)
         self.decode_warnings(fb)
+        logging.debug("decode_cellinfo_jk02(): self.frame_buffer")
+        logging.debug(self.frame_buffer)
         logging.debug(self.bms_status)
 
     def decode_settings_jk02(self):
@@ -255,6 +257,10 @@ class Jkbms_Brn:
         self._new_data_callback = callback
 
     def assemble_frame(self, data: bytearray):
+        logging.debug(
+            f"--> assemble_frame() -> self.frame_buffer (before extend) -> lenght:  {len(self.frame_buffer)}"
+        )
+        logging.debug(self.frame_buffer)
         if len(self.frame_buffer) > MAX_RESPONSE_SIZE:
             logging.info(
                 "data dropped because it alone was longer than max frame length"
@@ -267,6 +273,10 @@ class Jkbms_Brn:
 
         self.frame_buffer.extend(data)
 
+        logging.debug(
+            f"--> assemble_frame() -> self.frame_buffer (after extend) -> lenght:  {len(self.frame_buffer)}"
+        )
+        logging.debug(self.frame_buffer)
         if len(self.frame_buffer) >= MIN_RESPONSE_SIZE:
             # check crc; always at position 300, independent of
             # actual frame-lentgh, so crc up to 299
@@ -282,6 +292,8 @@ class Jkbms_Brn:
 
     def ncallback(self, sender: int, data: bytearray):
         logging.debug(f"--> NEW PACKAGE! lenght:  {len(data)}")
+        logging.debug("ncallback(): data")
+        logging.debug(data)
         self.assemble_frame(data)
 
     def crc(self, arr: bytearray, length: int) -> int:

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -296,16 +296,18 @@ LIPRO_CELL_COUNT = 15
 HELTEC_MODBUS_ADDR = 1
 
 
-; --------- Battery monitor specific settings ---------
-; If you are using a SmartShunt or something else as a battery monitor, the battery voltage reported
-; from the BMS and SmartShunt could differ. This causes, that the driver never goapplies the float voltage,
-; since max voltage is never reached.
+; --------- Voltage drop ---------
+; If you have a voltage drop between the BMS and the charger because of wire size or length
+; then you can specify the voltage drop here. The driver will then add the voltage drop
+; to the calculated CVL to compensate.
 ; Example:
 ;     cell count: 16
 ;     MAX_CELL_VOLTAGE = 3.45
 ;     max voltage calculated = 16 * 3.45 = 55.20
-;     CVL is set to 55.20 and the battery is now charged until the SmartShunt measures 55.20 V. The BMS
-;     now measures 55.05 V since there is a voltage drop of 0.15 V. Since the dbus-serialbattery measures
-;     55.05 V the max voltage is never reached for the driver and max voltage is kept forever.
-;     Set VOLTAGE_DROP to 0.15
+;     CVL is set to 55.20 V and the battery is now charged until the charger reaches 55.20 V.
+;     The BMS now measures 55.05 V since there is a voltage drop of 0.15 V on the cable.
+;     Since the dbus-serialbattery reads the voltage of 55.05 V from the BMS the max voltage
+;     of 55.20 V is never reached and max voltage is kept forever.
+;     By setting the VOLTAGE_DROP to 0.15 V the voltage on the charger is increased and the
+;     target voltage on the BMS is reached.
 VOLTAGE_DROP = 0.00

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -13,19 +13,19 @@ MAX_CELL_VOLTAGE   = 3.450
 ; Float voltage (can be seen as resting voltage)
 FLOAT_CELL_VOLTAGE = 3.375
 
-; Bulk voltage (may be needed to reset the SoC to 100% once in a while for some BMS)
+; SOC reset voltage (may be needed to reset the SoC to 100% once in a while for some BMS)
 ; Has to be higher as the MAX_CELL_VOLTAGE
-BULK_CELL_VOLTAGE  = 3.650
-; Specify after how many days the bulk voltage should be reached again
-; The timer is reset when the bulk voltage is reached
+SOC_RESET_VOLTAGE  = 3.650
+; Specify after how many days the soc reset voltage should be reached again
+; The timer is reset when the soc reset voltage is reached
 ; Leave empty if you don't want to use this
 ; Example: Value is set to 15
-; day 1: bulk reached once
-; day 16: bulk reached twice
-; day 31: bulk not reached since it's very cloudy
-; day 34: bulk reached since the sun came out
-; day 49: bulk reached again, since last time it took 3 days to reach bulk voltage
-BULK_AFTER_DAYS =
+; day 1: soc reset reached once
+; day 16: soc reset reached twice
+; day 31: soc reset not reached since it's very cloudy
+; day 34: soc reset reached since the sun came out
+; day 49: soc reset reached again, since last time it took 3 days to reach soc reset voltage
+SOC_RESET_AFTER_DAYS =
 
 ; --------- Bluetooth BMS ---------
 ; Description: List the Bluetooth BMS here that you want to install

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -482,7 +482,9 @@ class DbusHelper:
         self._dbusservice["/System/Temperature4Name"] = utils.TEMP_4_NAME
 
         # Voltage control
-        self._dbusservice["/Info/MaxChargeVoltage"] = self.battery.control_voltage
+        self._dbusservice["/Info/MaxChargeVoltage"] = round(
+            self.battery.control_voltage + utils.VOLTAGE_DROP, 2
+        )
 
         # Charge control
         self._dbusservice[

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -482,8 +482,10 @@ class DbusHelper:
         self._dbusservice["/System/Temperature4Name"] = utils.TEMP_4_NAME
 
         # Voltage control
-        self._dbusservice["/Info/MaxChargeVoltage"] = round(
-            self.battery.control_voltage + utils.VOLTAGE_DROP, 2
+        self._dbusservice["/Info/MaxChargeVoltage"] = (
+            round(self.battery.control_voltage + utils.VOLTAGE_DROP, 2)
+            if self.battery.control_voltage is not None
+            else None
         )
 
         # Charge control

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -522,8 +522,8 @@ class DbusHelper:
         self._dbusservice["/Alarms/HighVoltage"] = (
             self.battery.protection.voltage_high
             if (
-                self.battery.bulk_requested is False
-                and self.battery.bulk_last_reached < int(time()) - (60 * 30)
+                self.battery.soc_reset_requested is False
+                and self.battery.soc_reset_last_reached < int(time()) - (60 * 30)
             )
             else 0
         )

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -66,15 +66,15 @@ if FLOAT_CELL_VOLTAGE < MIN_CELL_VOLTAGE:
         ">>> ERROR: FLOAT_CELL_VOLTAGE is set to a value less than MAX_CELL_VOLTAGE. Please check the configuration."
     )
 
-BULK_CELL_VOLTAGE = float(config["DEFAULT"]["BULK_CELL_VOLTAGE"])
-if BULK_CELL_VOLTAGE < MAX_CELL_VOLTAGE:
-    BULK_CELL_VOLTAGE = MAX_CELL_VOLTAGE
+SOC_RESET_VOLTAGE = float(config["DEFAULT"]["SOC_RESET_VOLTAGE"])
+if SOC_RESET_VOLTAGE < MAX_CELL_VOLTAGE:
+    SOC_RESET_VOLTAGE = MAX_CELL_VOLTAGE
     logger.error(
-        ">>> ERROR: BULK_CELL_VOLTAGE is set to a value less than MAX_CELL_VOLTAGE. Please check the configuration."
+        ">>> ERROR: SOC_RESET_VOLTAGE is set to a value less than MAX_CELL_VOLTAGE. Please check the configuration."
     )
-BULK_AFTER_DAYS = (
-    int(config["DEFAULT"]["BULK_AFTER_DAYS"])
-    if config["DEFAULT"]["BULK_AFTER_DAYS"] != ""
+SOC_RESET_AFTER_DAYS = (
+    int(config["DEFAULT"]["SOC_RESET_AFTER_DAYS"])
+    if config["DEFAULT"]["SOC_RESET_AFTER_DAYS"] != ""
     else False
 )
 

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -38,7 +38,7 @@ def _get_list_from_config(
 
 
 # Constants
-DRIVER_VERSION = "1.0.20230921dev"
+DRIVER_VERSION = "1.0.20230927dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 


### PR DESCRIPTION
## Breaking changes

* Driver version greater or equal to `v1.0.20230629beta` and smaller or equal to `v1.0.20230926beta`:

  With `v1.0.20230927beta` the following values changed names:
  * `BULK_CELL_VOLTAGE` -> `SOC_RESET_VOLTAGE`
  * `BULK_AFTER_DAYS` -> `SOC_RESET_AFTER_DAYS`

* Changed: `VOLTAGE_DROP` now behaves differently. Before it reduced the voltage for the check, now the voltage for the charger is increased in order to get the target voltage on the BMS by @mr-manuel
* Changed: JKBMS - Driver do not start if manufacturer date in BMS is empty https://github.com/Louisvdw/dbus-serialbattery/issues/823 by @mr-manuel