### PR TITLE
Changes 2023.11.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ## Breaking changes
 
-* Driver version greater or equal to `v1.0.20231126beta`
+* Driver version greater or equal to `v1.0.20231128beta`
 
-  The custom name is not saved to the config file anymore, but to the dbus service com.victronenergy.settings. You have to re-enter it once.
+  * The custom name is not saved to the config file anymore, but to the dbus service com.victronenergy.settings. You have to re-enter it once.
+
+  * If you selected a specific device in `Settings -> System setup -> Battery monitor` and/or `Settings -> DVCC -> Controlling BMS` you have to reselect it.
 
 * Driver version greater or equal to `v1.0.20230629beta` and smaller or equal to `v1.0.20230926beta`:
 

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -205,7 +205,7 @@ class DbusHelper:
                         ["ClassAndVrmInstance"],
                     )
                     logger.info(
-                        f"Remove /Settings/Devices/{key} from dbus."
+                        f"Remove /Settings/Devices/{key} from dbus. "
                         + f"Old entry. Delete result: {del_return}"
                     )
 
@@ -899,6 +899,10 @@ class DbusHelper:
             )
             pass
 
+        # save settings every 15 seconds to dbus
+        if int(time()) % 15:
+            self.saveBatteryOptions()
+
         if self.battery.soc is not None:
             logger.debug("logged to dbus [%s]" % str(round(self.battery.soc, 2)))
             self.battery.log_cell_data()
@@ -1008,8 +1012,8 @@ class DbusHelper:
         )
         return value if result else None
 
-    # save charge mode to dbus
-    def saveChargeDetails(self) -> bool:
+    # save battery options to dbus
+    def saveBatteryOptions(self) -> bool:
         if (
             self.battery.allow_max_voltage
             != self.save_charge_details_last["allow_max_voltage"]

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -52,9 +52,9 @@ class DbusHelper:
         )
         self.path_battery = None
         self.save_charge_details_last = {
-            "allow_max_voltage": None,
-            "max_voltage_start_time": None,
-            "soc_reset_last_reached": None,
+            "allow_max_voltage": self.battery.allow_max_voltage,
+            "max_voltage_start_time": self.battery.max_voltage_start_time,
+            "soc_reset_last_reached": self.battery.soc_reset_last_reached,
         }
 
     def setup_instance(self):
@@ -1014,6 +1014,8 @@ class DbusHelper:
 
     # save battery options to dbus
     def saveBatteryOptions(self) -> bool:
+        result = True
+
         if (
             self.battery.allow_max_voltage
             != self.save_charge_details_last["allow_max_voltage"]
@@ -1021,7 +1023,7 @@ class DbusHelper:
             self.save_charge_details_last[
                 "allow_max_voltage"
             ] = self.battery.allow_max_voltage
-            result = self.setSetting(
+            result = result + self.setSetting(
                 get_bus(),
                 "com.victronenergy.settings",
                 self.path_battery,
@@ -1069,8 +1071,8 @@ class DbusHelper:
                 self.battery.soc_reset_last_reached,
             )
             logger.info(
-                f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, ",
-                +f"after {self.battery.soc_reset_last_reached}",
+                f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, "
+                + f"after {self.battery.soc_reset_last_reached}",
             )
 
         return result

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -37,7 +37,7 @@ def _get_list_from_config(
 
 
 # Constants
-DRIVER_VERSION = "1.0.20231126dev"
+DRIVER_VERSION = "1.0.20231127dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -37,7 +37,7 @@ def _get_list_from_config(
 
 
 # Constants
-DRIVER_VERSION = "1.0.20231127dev"
+DRIVER_VERSION = "1.0.20231128dev"
 zero_char = chr(48)
 degree_sign = "\N{DEGREE SIGN}"
 


### PR DESCRIPTION
## Breaking changes

* Driver version greater or equal to `v1.0.20231128beta`

  * The custom name is not saved to the config file anymore, but to the dbus service com.victronenergy.settings. You have to re-enter it once.

  * If you selected a specific device in `Settings -> System setup -> Battery monitor` and/or `Settings -> DVCC -> Controlling BMS` you have to reselect it.

* Added: Save current charge state for driver restart or device reboot. Fixes https://github.com/Louisvdw/dbus-serialbattery/issues/840 by @mr-manuel
* Added: The device instance does not change anymore when you plug the BMS into another USB port. Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/718 by @mr-manuel