### PR TITLE
Enhancement of CVL-controller 

### DIFF
--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -360,20 +360,23 @@ class Battery(ABC):
                 ):
                     self.max_voltage_start_time = None
 
-            if self.control_voltage:
-                controlvoltage = self.control_voltage - (
-                    (
-                        self.get_max_cell_voltage()
-                        - utils.MAX_CELL_VOLTAGE
-                        - utils.CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL
+            if utils.CVL_ICONTROLLER_MODE:
+                if self.control_voltage:
+                    controlvoltage = self.control_voltage - (
+                        (
+                            self.get_max_cell_voltage()
+                            - utils.MAX_CELL_VOLTAGE
+                            - utils.CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL
+                        )
+                        * utils.CVL_ICONTROLLER_FACTOR
                     )
-                    / 6.0
+                else:
+                    controlvoltage = utils.MAX_CELL_VOLTAGE * self.cell_count
+
+                controlvoltage = min(
+                    max(controlvoltage, self.min_battery_voltage),
+                    self.max_battery_voltage,
                 )
-            else:
-                controlvoltage = utils.MAX_CELL_VOLTAGE * self.cell_count
-            controlvoltage = min(
-                max(controlvoltage, self.min_battery_voltage), self.max_battery_voltage
-            )
 
             # INFO: battery will only switch to Absorption, if all cells are balanced.
             #       Reach MAX_CELL_VOLTAGE * cell count if they are all balanced.
@@ -389,8 +392,10 @@ class Battery(ABC):
                     ),
                     3,
                 )
-                # self.set_cvl_linear(control_voltage)
-                self.control_voltage = controlvoltage
+                if utils.CVL_ICONTROLLER_MODE:
+                    self.control_voltage = controlvoltage
+                else:
+                    self.set_cvl_linear(control_voltage)
 
                 self.charge_mode = (
                     "Bulk dynamic"
@@ -402,8 +407,10 @@ class Battery(ABC):
                     self.charge_mode += " & SoC Reset"
 
             elif self.allow_max_voltage:
-                # self.control_voltage = round(self.max_battery_voltage, 3)
-                self.control_voltage = controlvoltage
+                if utils.CVL_ICONTROLLER_MODE:
+                    self.control_voltage = controlvoltage
+                else:
+                    self.control_voltage = round(self.max_battery_voltage, 3)
 
                 self.charge_mode = (
                     "Bulk" if self.max_voltage_start_time is None else "Absorption"

--- a/etc/dbus-serialbattery/battery.py
+++ b/etc/dbus-serialbattery/battery.py
@@ -288,6 +288,7 @@ class Battery(ABC):
         voltageSum = 0
         penaltySum = 0
         tDiff = 0
+        controlvoltage = 0
         current_time = int(time())
 
         # meassurment and variation tolerance in volts
@@ -359,6 +360,21 @@ class Battery(ABC):
                 ):
                     self.max_voltage_start_time = None
 
+            if self.control_voltage:
+                controlvoltage = self.control_voltage - (
+                    (
+                        self.get_max_cell_voltage()
+                        - utils.MAX_CELL_VOLTAGE
+                        - utils.CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL
+                    )
+                    / 6.0
+                )
+            else:
+                controlvoltage = utils.MAX_CELL_VOLTAGE * self.cell_count
+            controlvoltage = min(
+                max(controlvoltage, self.min_battery_voltage), self.max_battery_voltage
+            )
+
             # INFO: battery will only switch to Absorption, if all cells are balanced.
             #       Reach MAX_CELL_VOLTAGE * cell count if they are all balanced.
             if foundHighCellVoltage and self.allow_max_voltage:
@@ -373,7 +389,8 @@ class Battery(ABC):
                     ),
                     3,
                 )
-                self.set_cvl_linear(control_voltage)
+                # self.set_cvl_linear(control_voltage)
+                self.control_voltage = controlvoltage
 
                 self.charge_mode = (
                     "Bulk dynamic"
@@ -385,7 +402,9 @@ class Battery(ABC):
                     self.charge_mode += " & SoC Reset"
 
             elif self.allow_max_voltage:
-                self.control_voltage = round(self.max_battery_voltage, 3)
+                # self.control_voltage = round(self.max_battery_voltage, 3)
+                self.control_voltage = controlvoltage
+
                 self.charge_mode = (
                     "Bulk" if self.max_voltage_start_time is None else "Absorption"
                 )

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -168,6 +168,7 @@ MAX_DISCHARGE_CURRENT_CV_FRACTION =    0,  0.1,  0.5,    1
 ;   1. PenaltySum-Method (CVL_ICONTROLLER_MODE = False)
 ;      The voltage-overshoot of all cells that exceed MAX_CELL_VOLTAGE is summed up and the control voltage is lowered by this "penaltysum".
 ;      This is calculated every LINEAR_RECALCULATION_EVERY seconds.
+;      In fact, this is a P-Controller.
 ;   2. I-Controller (CVL_ICONTROLLER_MODE = True)
 ;      An I-Controller tries to control the voltage of the highest cell to MAX_CELL_VOLTAGE + CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL.
 ;      (for example 3.45V+0.01V =3.46V). If the voltage of the highest cell is above this level, CVL is reduced. If the voltage is below, CVL is 

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -150,6 +150,32 @@ MAX_CHARGE_CURRENT_CV_FRACTION =    0, 0.05,  0.5,    1
 CELL_VOLTAGES_WHILE_DISCHARGING   = 2.70, 2.80, 2.90, 3.10
 MAX_DISCHARGE_CURRENT_CV_FRACTION =    0,  0.1,  0.5,    1
 
+; --------- Cell Voltage limitation (affecting CVL) ---------
+; This function prevents a bad balanced battery to overcharge the cell with the highest voltage and the bms to
+; switch off because of overvoltage of this cell.
+;
+; Example:
+; 15 cells are at 3.4v, 1 cell is at 3.6v. Total voltage of battery is 54.6v and the Victron System sees no reason to
+; lower the charging current as the control_voltage (Absorbtion Voltage) ist 55.2v
+; In this case the Cell Voltage limitation kicks in and lowers the control_voltage to keep it close to the MAX_CELL_VOLTAGE.
+;
+; In theory this can also be done with CCL, but doing it with CVL has 2 advantages:
+;   - In a well balanced system the current can be kept quite high till the end of charge by using MAX_CELL_VOLTAGE for charging.
+;   - In systems with MPPTs and DC-feed-in activated the victron systems do not respect CCL, so CVL is the only way to prevent the
+;     highest cell in a bad balanced system from overcharging.
+;
+; There are 2 methods implemented to calculate CVL:
+;   1. PenaltySum-Method (CVL_ICONTROLLER_MODE = False)
+;      The voltage-overshoot of all cells that exceed MAX_CELL_VOLTAGE is summed up and the control voltage is lowered by this "penaltysum".
+;      This is calculated every LINEAR_RECALCULATION_EVERY seconds.
+;   2. I-Controller (CVL_ICONTROLLER_MODE = True)
+;      An I-Controller tries to control the voltage of the highest cell to MAX_CELL_VOLTAGE + CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_UNTIL.
+;      (for example 3.45V+0.01V =3.46V). If the voltage of the highest cell is above this level, CVL is reduced. If the voltage is below, CVL is 
+;      increased until cellcount*MAX_CELL_VOLTAGE.
+;      An I-Part of 0.2 V/Vs (CVL_ICONTROLLER_FACTOR) has proved to be a stable and fast controlling-behaviour.
+;      This method is not as fast as the PenaltySum-Method but usually smoother and more stable against toggeling and has no stationary deviation.
+CVL_ICONTROLLER_MODE = False 
+CVL_ICONTROLLER_FACTOR = 0.2
 
 ; --------- Temperature limitation (affecting CCL/DCL) ---------
 ; Description: Maximal charge / discharge current will be in-/decreased depending on temperature

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -139,6 +139,11 @@ MAX_DISCHARGE_CURRENT_CV = _get_list_from_config(
     lambda v: MAX_BATTERY_DISCHARGE_CURRENT * float(v),
 )
 
+# --------- Cell Voltage limitation (affecting CVL) ---------
+
+CVL_ICONTROLLER_MODE = "True" == config["DEFAULT"]["CVL_ICONTROLLER_MODE"]
+CVL_ICONTROLLER_FACTOR = float(config["DEFAULT"]["CVL_ICONTROLLER_FACTOR"])
+
 # --------- Temperature limitation (affecting CCL/DCL) ---------
 CCCM_T_ENABLE = "True" == config["DEFAULT"]["CCCM_T_ENABLE"]
 DCCM_T_ENABLE = "True" == config["DEFAULT"]["DCCM_T_ENABLE"]


### PR DESCRIPTION
A big advantage of serialbattery-driver compared to a victron-system with a smartshun-system is, that the serialbus-driver sees every cell voltage and can react on bad balanced batteries.

Especially at the end of charging (close to 100%) the charging-current is usually controlled indirect by CVL (Charge Voltage Limitation).
Furthermore in Victron Systems with MPPTs and DC-Feed-In activated CVL is the only way to reduce charging current, because CCL (charge current limitation does only apply to Multis, but not to MPPTs.

So it is a very good feature of the driver, that CVL can be reduced if a single cell runs over MAX_CELL_VOLTAGE.
This is implemented today with a "penaltySum"-Method that is in fact a P-Controller.

I think an I-Controller fits better to the requirements of CVL-Controlling.
This is implemented with this PR.
With the switch `CVL_ICONTROLLER_MODE` the PenaltySum (`CVL_ICONTROLLER_MODE`=false) or a I-Controller (`CVL_ICONTROLLER_MODE`=True) can be choosen.

I made a test with each controller. With a power-supply I charged a single cell (cell no3) for 1.5h with 2Amps. So I got the cell3 about 3Ah higher than the rest of the 16s-Pack.
![image](https://github.com/Louisvdw/dbus-serialbattery/assets/125555670/c40400b2-57da-4baa-9ab8-cd6e6fc12e5d)

Then I charged the battery-pack to 100%. And the balancer got it right again.

Here is the result:
 
![image](https://github.com/Louisvdw/dbus-serialbattery/assets/125555670/2d4d5b34-0151-4a67-91ea-f293921b597c)

An I-Controller provides a calmer CVL and so gives the victron system time to adjust the charging-current to meet the CVL.