### PR TITLE
Add setting and install logic for usb bluetooth module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Added: The device instance does not change anymore when you plug the BMS into another USB port. Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/718 by @mr-manuel
 * Added: Use current average of the last 300 cycles for time to go and time to SoC calculation by @mr-manuel
 * Added: Validate current, voltage, capacity and SoC for all BMS. This prevents that a device, which is no BMS, is detected as BMS. Fixes also https://github.com/Louisvdw/dbus-serialbattery/issues/479 by @mr-manuel
+* Added: Setting and install logic for usb bluetooth module by @Marvo2011
 * Changed: `VOLTAGE_DROP` now behaves differently. Before it reduced the voltage for the check, now the voltage for the charger is increased in order to get the target voltage on the BMS by @mr-manuel
 * Changed: Daly BMS - Fix readsentence by @transistorgit
 * Changed: Daly BMS - Fixed https://github.com/Louisvdw/dbus-serialbattery/issues/837 by @mr-manuel

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -58,6 +58,7 @@ BLUETOOTH_BMS =
 ; Description:  Some users reported issues to the built in bluetooth module, you can try to fix it with an USB
 ;               module. After a change you have to run reinstall-local.sh and to manual reboot the device!
 ;               The usb bluetooth module must have BLE support (bluetooth version >= 4.0)
+;               Other bluetooth devices such as Ruvi tags not tested yet.
 ; False: Use the built in bluetooth module
 ; True: Disable built in bluetooth module and try to use USB module
 BLUETOOTH_USE_USB = False

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -54,6 +54,14 @@ SOC_RESET_AFTER_DAYS =
 ; BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00, Jkbms_Ble C8:47:8C:00:00:11, Jkbms_Ble C8:47:8C:00:00:22
 BLUETOOTH_BMS =
 
+; --------- Bluetooth use USB ---------
+; Description:  Some users reported issues to the built in bluetooth module, you can try to fix it with an USB
+;               module. After a change you have to run reinstall-local.sh and to manual reboot the device!
+;               The usb bluetooth module must have BLE support (bluetooth version >= 4.0)
+; False: Use the built in bluetooth module
+; True: Disable built in bluetooth module and try to use USB module
+BLUETOOTH_USE_USB = False
+
 ; --------- CAN BMS ---------
 ; Description: Specify the CAN port(s) where the BMS is connected to. Leave empty to disable
 ; -- Available CAN BMS:

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -58,7 +58,7 @@ BLUETOOTH_BMS =
 ; Description:  Some users reported issues to the built in bluetooth module, you can try to fix it with an USB
 ;               module. After a change you have to run reinstall-local.sh and to manual reboot the device!
 ;               The usb bluetooth module must have BLE support (bluetooth version >= 4.0)
-;               Other bluetooth devices such as Ruvi tags not tested yet.
+;               Other bluetooth devices such as Ruuvi tags not tested yet.
 ; False: Use the built in bluetooth module
 ; True: Disable built in bluetooth module and try to use USB module
 BLUETOOTH_USE_USB = False

--- a/etc/dbus-serialbattery/reinstall-local.sh
+++ b/etc/dbus-serialbattery/reinstall-local.sh
@@ -131,6 +131,22 @@ pkill -f "python .*/dbus-serialbattery.py /dev/tty.*"
 
 ### BLUETOOTH PART | START ###
 
+# get bluetooth mode integrated/usb
+bluetooth_use_usb=$(awk -F "=" '/^BLUETOOTH_USE_USB/ {print $2}' /data/etc/dbus-serialbattery/config.ini)
+
+# replace dtoverlay in /u-boot/config.txt this needs a reboot!
+if [[ $bluetooth_use_usb == *"True"* ]]; then
+    if grep -q -r "miniuart-bt" /u-boot/config.txt; then
+        sed -i 's/miniuart-bt/disable-bt/g' /u-boot/config.txt
+        echo "ATTENTION! You have changed the bluetooth mode to USB! THIS NEEDS A MANUAL REBOOT!"
+    fi
+elif [[ $bluetooth_use_usb == *"False"* ]]; then
+    if grep -q -r "disable-bt" /u-boot/config.txt; then
+        sed -i 's/disable-bt/miniuart-bt/g' /u-boot/config.txt
+        echo "ATTENTION! You have changed the bluetooth mode to built in module! THIS NEEDS A MANUAL REBOOT!"
+    fi
+fi
+
 # get BMS list from config file
 bluetooth_bms=$(awk -F "=" '/^BLUETOOTH_BMS/ {print $2}' /data/etc/dbus-serialbattery/config.ini)
 #echo $bluetooth_bms


### PR DESCRIPTION
Some users have trouble with the integrated bluetooth in Raspberry Pi's, here I add a setting and install logic for an usb bluetooth module.

Usage: 
- buy a usb bluetooth module with BLE support (bluetooth version > 4.0)
- add `BLUETOOTH_USE_USB = True` to config.ini
- run `/data/etc/dbus-serialbattery/reinstall-local.sh`
- do a `reboot`! 

Should fix: #777 
Should supersede: #830 