### PR TITLE
Bugfix 950 dev

### DIFF
--- a/etc/dbus-serialbattery/bms/daly_can.py
+++ b/etc/dbus-serialbattery/bms/daly_can.py
@@ -90,7 +90,7 @@ class Daly_Can(Battery):
 
     def get_settings(self):
         self.capacity = BATTERY_CAPACITY
-        self.max_battery_current = MAX_BATTERY_CHARGE_CURRENT
+        self.max_battery_charge_current = MAX_BATTERY_CHARGE_CURRENT
         self.max_battery_discharge_current = MAX_BATTERY_DISCHARGE_CURRENT
         return True
 

--- a/etc/dbus-serialbattery/bms/jkbms_can.py
+++ b/etc/dbus-serialbattery/bms/jkbms_can.py
@@ -48,12 +48,13 @@ class Jkbms_Can(Battery):
     ALM_INFO = "ALM_INFO"
 
     MESSAGES_TO_READ = 100
-
+    
+    # Changed from 0x0XF4 to 0x0XF5. See https://github.com/Louisvdw/dbus-serialbattery/issues/950
     CAN_FRAMES = {
-        BATT_STAT: 0x02F4,
-        CELL_VOLT: 0x04F4,
-        CELL_TEMP: 0x05F4,
-        ALM_INFO: 0x07F4,
+        BATT_STAT: 0x02F5,
+        CELL_VOLT: 0x04F5,
+        CELL_TEMP: 0x05F5,
+        ALM_INFO: 0x07F5,
     }
 
     def test_connection(self):
@@ -66,7 +67,7 @@ class Jkbms_Can(Battery):
         # After successful  connection get_settings will be call to set up the battery.
         # Set the current limits, populate cell count, etc
         # Return True if success, False for failure
-        self.max_battery_current = MAX_BATTERY_CHARGE_CURRENT
+        self.max_battery_charge_current = MAX_BATTERY_CHARGE_CURRENT
         self.max_battery_discharge_current = MAX_BATTERY_DISCHARGE_CURRENT
         self.max_battery_voltage = MAX_CELL_VOLTAGE * self.cell_count
         self.min_battery_voltage = MIN_CELL_VOLTAGE * self.cell_count


### PR DESCRIPTION
Fixing bug https://github.com/Louisvdw/dbus-serialbattery/issues/950

The only question is, if it worked on some devices before or not ?  If the `CAN_FRAMES` change will  break other devices or not ?

Result with the fix applied:
![image](https://github.com/Louisvdw/dbus-serialbattery/assets/311609/bfd89638-5357-483a-815e-2692f488e2d9)
![image](https://github.com/Louisvdw/dbus-serialbattery/assets/311609/0d83ca62-f35a-47d5-a758-4ce9451f9b69)
![image](https://github.com/Louisvdw/dbus-serialbattery/assets/311609/65c13cc6-65be-429e-b123-200f656f94a1)

