### PR TITLE
Add `Renogy.unique_identifier` method to allow multiple batteries

### DIFF
--- a/etc/dbus-serialbattery/bms/renogy.py
+++ b/etc/dbus-serialbattery/bms/renogy.py
@@ -41,6 +41,10 @@ class Renogy(Battery):
     )
     # BMS warning and protection config
 
+
+    def unique_identifier(self) -> str:
+        return self.serial_number
+
     def test_connection(self):
         # call a function that will connect to the battery, send a command and retrieve the result.
         # The result or call should be unique to this BMS. Battery name or version, etc.
@@ -124,6 +128,9 @@ class Renogy(Battery):
 
         capacity = self.read_serial_data_renogy(self.command_capacity)
         self.capacity = unpack(">L", capacity)[0] / 1000.0
+
+        serial_number = self.read_serial_data_renogy(self.command_serial_number)
+        self.serial_number = unpack("16s", serial_number)[0].decode("utf-8")
 
         return True
 


### PR DESCRIPTION
After running into an issue with multiple Renogy batteries conflicting due to the `Renogy` class not having a `unique_identifier` method, thus, dropping back to hardware version, I've added this method to return the battery's serial number. This has allowed me to connect multiple nearly-identical batteries.