### PR TITLE
robustify deployment

### DIFF
--- a/etc/dbus-serialbattery/reinstall-local.sh
+++ b/etc/dbus-serialbattery/reinstall-local.sh
@@ -104,6 +104,8 @@ mkdir /opt/victronenergy/dbus-serialbattery/bms
 cp -f /data/etc/dbus-serialbattery/* /opt/victronenergy/dbus-serialbattery &>/dev/null
 cp -f /data/etc/dbus-serialbattery/bms/* /opt/victronenergy/dbus-serialbattery/bms &>/dev/null
 cp -rf /data/etc/dbus-serialbattery/service /opt/victronenergy/service-templates/dbus-serialbattery
+chmod +x /opt/victronenergy/dbus-serialbattery/*.sh
+chmod +x /opt/victronenergy/service-templates/dbus-serialbattery/*
 bash /data/etc/dbus-serialbattery/install-qml.sh
 
 # check if serial-starter.d was deleted

--- a/etc/dbus-serialbattery/reinstall-local.sh
+++ b/etc/dbus-serialbattery/reinstall-local.sh
@@ -101,11 +101,11 @@ rm -rf /opt/victronenergy/service-templates/dbus-serialbattery
 rm -rf /opt/victronenergy/dbus-serialbattery
 mkdir /opt/victronenergy/dbus-serialbattery
 mkdir /opt/victronenergy/dbus-serialbattery/bms
+chmod +x /data/etc/dbus-serialbattery/*.sh
+chmod +x /data/etc/dbus-serialbattery/service/*
 cp -f /data/etc/dbus-serialbattery/* /opt/victronenergy/dbus-serialbattery &>/dev/null
 cp -f /data/etc/dbus-serialbattery/bms/* /opt/victronenergy/dbus-serialbattery/bms &>/dev/null
 cp -rf /data/etc/dbus-serialbattery/service /opt/victronenergy/service-templates/dbus-serialbattery
-chmod +x /opt/victronenergy/dbus-serialbattery/*.sh
-chmod +x /opt/victronenergy/service-templates/dbus-serialbattery/*
 bash /data/etc/dbus-serialbattery/install-qml.sh
 
 # check if serial-starter.d was deleted


### PR DESCRIPTION
Sometimes it can happen that the run file or the shell scripts don't have the executable-flag set. Using this change guarantees that the executable flag is set within the deployed folder.